### PR TITLE
fix: Wrap single items on to_form

### DIFF
--- a/lib/ash_phoenix/form/form.ex
+++ b/lib/ash_phoenix/form/form.ex
@@ -1665,6 +1665,7 @@ defmodule AshPhoenix.Form do
             |> to_form(opts)
             |> Map.put(:name, form.name <> "[#{field}]")
             |> Map.put(:id, form.id <> "_#{field}")
+            |> List.wrap()
           end
 
         :list ->

--- a/test/form_test.exs
+++ b/test/form_test.exs
@@ -57,7 +57,7 @@ defmodule AshPhoenix.FormTest do
 
       assert form.errors == []
 
-      assert inputs_for(form, :post).errors == [{:text, {"is required", []}}]
+      assert hd(inputs_for(form, :post)).errors == [{:text, {"is required", []}}]
     end
 
     test "nested forms submit empty values when not present in input params" do
@@ -290,7 +290,7 @@ defmodule AshPhoenix.FormTest do
         |> form_for("action")
 
       assert %Phoenix.HTML.Form{source: %AshPhoenix.Form{resource: AshPhoenix.Test.Post}} =
-               related_form = inputs_for(form, :post)
+               related_form = hd(inputs_for(form, :post))
 
       assert related_form.name == "form[post]"
 
@@ -508,6 +508,27 @@ defmodule AshPhoenix.FormTest do
         |> Form.validate(%{})
 
       assert Form.params(form) == %{"post" => []}
+    end
+
+    test "when `:single`, `inputs_for` generates a list of one single item" do
+      post_id = Ash.UUID.generate()
+      comment = %Comment{text: "text", post: %Post{id: post_id, text: "Some text"}}
+
+      form =
+        comment
+        |> Form.for_update(:update,
+          forms: [
+            post: [
+              data: comment.post,
+              type: :single,
+              resource: Post,
+              update_action: :update
+            ]
+          ]
+        )
+
+      assert [%Phoenix.HTML.Form{source: %AshPhoenix.Form{resource: AshPhoenix.Test.Post}}] =
+               inputs_for(form_for(form, "action"), :post)
     end
   end
 end


### PR DESCRIPTION
When using `inputs_for`, most (all?) examples with liveview show using it with a for comprehension, even if it's used over a single embedded item. Surface `<Inputs ...>` component also assumes inputs_for is going to return a list.

Here's a test and a naive solution to the issue. There seems to be another issue when nesting other forms under a `:single` resource (the form key for the further nested form is not found). I'm not sure if that's caused by the fix in this PR!
