### PR TITLE
fix: Fix default form id when :as provided

### DIFF
--- a/lib/ash_phoenix/form/form.ex
+++ b/lib/ash_phoenix/form/form.ex
@@ -174,8 +174,8 @@ defmodule AshPhoenix.Form do
     ],
     id: [
       type: :string,
-      default: "form",
-      doc: "The html id of the form."
+      doc:
+        "The html id of the form. Defaults to the value of `:as` if provided, otherwise \"form\""
     ],
     transform_errors: [
       type: {:fun, 2},

--- a/test/form_test.exs
+++ b/test/form_test.exs
@@ -16,6 +16,11 @@ defmodule AshPhoenix.FormTest do
 
       assert FormData.input_value(form.source, form, :text) == "text"
     end
+
+    test "it sets the default id of a form" do
+      assert Form.for_create(Post, :create).id == "form"
+      assert Form.for_create(Post, :create, as: "post").id == "post"
+    end
   end
 
   describe "errors" do


### PR DESCRIPTION
Form id is preset to "form" before checking value of `opts[:as]`