### PR TITLE
Failing test case: field names incorrectly rendered in form

### DIFF
--- a/test/form_test.exs
+++ b/test/form_test.exs
@@ -303,6 +303,33 @@ defmodule AshPhoenix.FormTest do
   end
 
   describe "inputs_for` relationships" do
+    test "it should name the fields correctly on `for_update`" do
+      post_id = Ash.UUID.generate()
+      comment = %Comment{text: "text", post: %Post{id: post_id, text: "Some text"}}
+
+      form =
+        comment
+        |> Form.for_update(:update,
+          as: "comment",
+          forms: [
+            post: [
+              data: comment.post,
+              type: :single,
+              resource: Post,
+              update_action: :update
+            ]
+          ]
+        )
+
+      post_form =
+        form
+        |> form_for("action")
+        |> inputs_for(:post)
+        |> hd()
+
+      assert post_form.name == "comment_post[0]"
+    end
+
     test "the `type: :single` option should create a form without integer paths" do
       form =
         Comment
@@ -560,7 +587,7 @@ defmodule AshPhoenix.FormTest do
                inputs_for(form_for(form, "action"), :post)
     end
 
-    test "failing single intermediate form" do
+    test "it creates nested forms for single resources" do
       post_id = Ash.UUID.generate()
       comment_id = Ash.UUID.generate()
 


### PR DESCRIPTION
Field names are wrong on for nested forms on for_update

```
rendered as: directoryemails][0][[email]
should be:   directory_emails][0][email]
```