### PR TITLE
fix: Fix nested form naming

### DIFF
--- a/lib/ash_phoenix/form/form.ex
+++ b/lib/ash_phoenix/form/form.ex
@@ -1716,7 +1716,7 @@ defmodule AshPhoenix.Form do
                 prev_data_trail: prev_data_trail,
                 forms: opts[:forms] || [],
                 manage_relationship_source: manage_relationship_source(source_changeset, opts),
-                as: name <> "#{key}][#{index}][",
+                as: name <> "[#{key}][#{index}]",
                 id: id <> "_#{key}_#{index}"
               )
             end)

--- a/test/form_test.exs
+++ b/test/form_test.exs
@@ -303,6 +303,54 @@ defmodule AshPhoenix.FormTest do
   end
 
   describe "inputs_for` relationships" do
+    test "it should name the fields correctly on `for_update`" do
+      post_id = Ash.UUID.generate()
+      comment_id = Ash.UUID.generate()
+
+      comment = %Comment{
+        text: "text",
+        post: %Post{
+          id: post_id,
+          text: "Some text",
+          comments: [%Comment{id: comment_id}]
+        }
+      }
+
+      form =
+        comment
+        |> Form.for_update(:update,
+          as: "comment",
+          forms: [
+            post: [
+              data: comment.post,
+              type: :single,
+              resource: Post,
+              update_action: :update,
+              create_action: :create,
+              forms: [
+                comments: [
+                  data: & &1.comments,
+                  type: :list,
+                  resource: Comment,
+                  update_action: :update,
+                  create_action: :create
+                ]
+              ]
+            ]
+          ]
+        )
+
+      comments_form =
+        form
+        |> form_for("action")
+        |> inputs_for(:post)
+        |> hd()
+        |> inputs_for(:comments)
+        |> hd()
+
+      assert comments_form.name == "comment[post][comments][0]"
+    end
+
     test "the `type: :single` option should create a form without integer paths" do
       form =
         Comment
@@ -560,7 +608,7 @@ defmodule AshPhoenix.FormTest do
                inputs_for(form_for(form, "action"), :post)
     end
 
-    test "failing single intermediate form" do
+    test "it creates nested forms for single resources" do
       post_id = Ash.UUID.generate()
       comment_id = Ash.UUID.generate()
 


### PR DESCRIPTION
Field names are wrong on nested forms on for_update

```
rendered as: directoryemails][0][[email]
should be:   directory[emails][0][email]
```

It might only effect when a `:list` is nested under a `:single`?