### PR TITLE
Validation issue in rc

### DIFF
--- a/test/form_test.exs
+++ b/test/form_test.exs
@@ -25,7 +25,8 @@ defmodule AshPhoenix.FormTest do
 
   describe "validation errors are attached to fields" do
     form = Form.for_create(PostWithDefault, :create, api: Api)
-    form = Form.validate(form, %{"text" => ""})
+    form = AshPhoenix.Form.validate(form, %{"text" => ""}, errors: form.submitted_once?)
+    {:error, form} = Form.submit(form, params: %{"text" => ""})
     assert %{errors: [text: {"is required", []}]} = form_for(form, "foo")
     assert form.valid? == false
   end


### PR DESCRIPTION
refs #29 

I've updated the test with my scenario that fails using the rc. It appears the strategy I was using to hide errors on validation until the form was submitted at least once is no longer working:

```elixir
form = AshPhoenix.Form.validate(form, %{"text" => ""}, errors: form.submitted_once?)
```

Not sure if this is a valid way of doing this? I'll reach out on discord!
