### PR TITLE
improvement: allow inclusion of missing fields in form params

### DIFF
--- a/lib/ash_phoenix/form/form.ex
+++ b/lib/ash_phoenix/form/form.ex
@@ -225,6 +225,11 @@ defmodule AshPhoenix.Form do
       return a list of ash phoenix formatted errors, e.g `[{field :: atom, message :: String.t(), substituations :: Keyword.t()}]`
       """
     ],
+    include_when_empty: [
+      type: {:list, :atom},
+      doc:
+        "Include values for these forms even when empty, this makes it easy to unrelate resources from the form resource with a remove_form"
+    ],
     method: [
       type: :string,
       doc:
@@ -1504,7 +1509,12 @@ defmodule AshPhoenix.Form do
                 Map.put(params, to_string(config[:for] || key), nested_params)
               end
             else
-              params
+              if is_nil(form.forms[key]) &&
+                   Enum.member?(Keyword.get(form.opts, :include_when_empty, []), key) do
+                Map.put(params, to_string(config[:for] || key), nil)
+              else
+                params
+              end
             end
 
           :list ->
@@ -1541,7 +1551,12 @@ defmodule AshPhoenix.Form do
                 end)
               end
             else
-              params
+              if is_nil(form.forms[key]) &&
+                   Enum.member?(Keyword.get(form.opts, :include_when_empty, []), key) do
+                Map.put(params, to_string(config[:for] || key), nil)
+              else
+                params
+              end
             end
         end
       end)

--- a/lib/ash_phoenix/form/form.ex
+++ b/lib/ash_phoenix/form/form.ex
@@ -1551,12 +1551,7 @@ defmodule AshPhoenix.Form do
                 end)
               end
             else
-              if is_nil(form.forms[key]) &&
-                   Enum.member?(Keyword.get(form.opts, :include_when_empty, []), key) do
-                Map.put(params, to_string(config[:for] || key), [])
-              else
-                params
-              end
+              params
             end
         end
       end)

--- a/lib/ash_phoenix/form/form.ex
+++ b/lib/ash_phoenix/form/form.ex
@@ -1553,7 +1553,7 @@ defmodule AshPhoenix.Form do
             else
               if is_nil(form.forms[key]) &&
                    Enum.member?(Keyword.get(form.opts, :include_when_empty, []), key) do
-                Map.put(params, to_string(config[:for] || key), nil)
+                Map.put(params, to_string(config[:for] || key), [])
               else
                 params
               end

--- a/test/form_test.exs
+++ b/test/form_test.exs
@@ -3,7 +3,7 @@ defmodule AshPhoenix.FormTest do
   import Phoenix.HTML.Form, only: [form_for: 2, inputs_for: 2]
 
   alias AshPhoenix.Form
-  alias AshPhoenix.Test.{Api, Comment, OtherApi, Post, PostWithDefault}
+  alias AshPhoenix.Test.{Api, Author, Comment, OtherApi, Post, PostWithDefault}
   alias Phoenix.HTML.FormData
 
   describe "form_for fields" do
@@ -1131,6 +1131,27 @@ defmodule AshPhoenix.FormTest do
                |> inputs_for(:post)
                |> hd()
                |> inputs_for(:comments)
+    end
+  end
+
+  describe "issue #9000" do
+    test "when `remove_form`ing an existing `:single` relationship, a nil value is included in the params - if the form key is in the `include_when_empty` form opt" do
+      post =
+        Post
+        |> Ash.Changeset.new(%{text: "post"})
+        |> Ash.Changeset.set_argument(:author, %{email: "nigel@elixir-lang.org"})
+        |> Api.create!()
+
+      form =
+        post
+        |> Form.for_update(:update, api: Api, forms: [auto?: true], include_when_empty: [:author])
+
+      params =
+        form
+        |> Form.remove_form([:author])
+        |> Form.params()
+
+      assert is_nil(Map.get(params, "author", "doesnt exist!"))
     end
   end
 

--- a/test/support/registry.ex
+++ b/test/support/registry.ex
@@ -3,6 +3,7 @@ defmodule AshPhoenix.Test.Registry do
   use Ash.Registry
 
   entries do
+    entry(AshPhoenix.Test.Author)
     entry(AshPhoenix.Test.Comment)
     entry(AshPhoenix.Test.Post)
     entry(AshPhoenix.Test.PostLink)

--- a/test/support/resources/author.ex
+++ b/test/support/resources/author.ex
@@ -1,0 +1,21 @@
+defmodule AshPhoenix.Test.Author do
+  @moduledoc false
+  use Ash.Resource, data_layer: Ash.DataLayer.Ets
+
+  ets do
+    private?(true)
+  end
+
+  attributes do
+    uuid_primary_key(:id)
+    attribute(:email, :string, allow_nil?: false)
+  end
+
+  actions do
+    defaults([:create, :read, :update])
+  end
+
+  relationships do
+    has_many(:posts, AshPhoenix.Test.Post)
+  end
+end

--- a/test/support/resources/post.ex
+++ b/test/support/resources/post.ex
@@ -14,10 +14,12 @@ defmodule AshPhoenix.Test.Post do
 
   actions do
     create :create do
+      argument(:author, :map, allow_nil?: true)
       argument(:comments, {:array, :map})
       argument(:linked_posts, {:array, :map})
       change(manage_relationship(:comments, type: :direct_control))
       change(manage_relationship(:linked_posts, type: :direct_control))
+      change(manage_relationship(:author, type: :direct_control, on_missing: :unrelate))
     end
 
     update :update_with_replace do
@@ -27,13 +29,16 @@ defmodule AshPhoenix.Test.Post do
 
     update :update do
       primary?(true)
+      argument(:author, :map, allow_nil?: true)
       argument(:comments, {:array, :map})
       change(manage_relationship(:comments, type: :direct_control))
+      change(manage_relationship(:author, type: :direct_control, on_missing: :unrelate))
     end
   end
 
   relationships do
     has_many(:comments, AshPhoenix.Test.Comment)
+    belongs_to(:author, AshPhoenix.Test.Author)
     has_one(:featured_comment, AshPhoenix.Test.Comment, read_action: :featured)
 
     many_to_many(:linked_posts, AshPhoenix.Test.Post,


### PR DESCRIPTION
Added an option to include empty forms in `AshPhoenix.Form.params`, this allows us to unrelate / delete resources without having to manually massage the params before submit, I haven't test with has_many / many_to_many yet so I don't know if I'm missing anything, and have just removed the stuff I had pasted in the `:list`, section to save getting untested stuff merged. 

Also I'm not sure how I'd be able to configure this for nested forms, maybe copy the option to add_form?

Signed-off-by: kernel-io <kernel-io@users.noreply.github.com>

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
