### PR TITLE
feat: add custom HTTP status codes for specific types of errors that can be thrown

### DIFF
--- a/lib/ash_phoenix/plug/exception.ex
+++ b/lib/ash_phoenix/plug/exception.ex
@@ -1,0 +1,27 @@
+errors = [
+  {Ash.Error.Invalid.InvalidPrimaryKey, 400},
+  {Ash.Error.Query.InvalidArgument, 400},
+  {Ash.Error.Query.InvalidFilterValue, 400},
+  {Ash.Error.Query.NotFound, 404}
+]
+
+# Individual errors can have their own status codes that will propagate to the top-level
+# wrapper error
+for {module, status_code} <- errors do
+  defimpl Plug.Exception, for: module do
+    def status(_exception), do: unquote(status_code)
+    def actions(_exception), do: []
+  end
+end
+
+# Top-level Ash errors will use the highest status code of all of the wrapped child errors
+defimpl Plug.Exception,
+  for: [Ash.Error.Invalid, Ash.Error.Forbidden, Ash.Error.Framework, Ash.Error.Unknown] do
+  def status(%{errors: errors} = _exception) do
+    errors
+    |> Enum.map(&Plug.Exception.status/1)
+    |> Enum.max()
+  end
+
+  def actions(_exception), do: []
+end

--- a/test/plug_test.exs
+++ b/test/plug_test.exs
@@ -1,0 +1,27 @@
+defmodule AshPhoenix.PlugTest do
+  use ExUnit.Case
+
+  describe "status/1" do
+    test "for individual errors" do
+      error = %Ash.Error.Query.NotFound{}
+      assert 404 == Plug.Exception.status(error)
+    end
+
+    test "for top-level errors wrapping several errors" do
+      error_custom_code = %Ash.Error.Query.NotFound{}
+
+      # This is something that should never happen so will never have a custom status code
+      error_default_code = %Ash.Error.Framework.SynchronousEngineStuck{}
+
+      error = %Ash.Error.Invalid{errors: [error_custom_code]}
+      assert 404 == Plug.Exception.status(error)
+
+      error = %Ash.Error.Invalid{errors: [error_default_code]}
+      assert 500 == Plug.Exception.status(error)
+
+      # The highest error code is used when there are multiple child errors
+      error = %Ash.Error.Invalid{errors: [error_default_code, error_custom_code]}
+      assert 500 == Plug.Exception.status(error)
+    end
+  end
+end


### PR DESCRIPTION
Heavily inspired by https://github.com/phoenixframework/phoenix_ecto/blob/master/lib/phoenix_ecto/plug.ex, that provides appropriate HTTP status codes for Ecto-related errors.

This is only a small subset of the available errors within Ash that could have custom HTTP statuses, but they'd be the most common cases I think.

(shows a 400 error being returned for an invalid primary key, in this case it should be a UUID and is not)
<img width="1034" alt="Screenshot 2022-11-23 at 2 00 14 pm" src="https://user-images.githubusercontent.com/543859/203487173-a4cefdf5-3a95-41f6-8fb1-5e2cf615acc8.png">


### Contributor checklist

- [ ] Bug fixes include regression tests
- [x] Features include unit/acceptance tests
