### PR TITLE
docs: use string instead of atom for post_selector/1

### DIFF
--- a/documentation/tutorials/getting-started-with-ash-and-phoenix.md
+++ b/documentation/tutorials/getting-started-with-ash-and-phoenix.md
@@ -476,7 +476,7 @@ defmodule MyAshPhoenixAppWeb.ExampleLiveView do
 
   defp post_selector(posts) do
     for post <- posts do
-      {:"#{post.title}", post.id}
+      {post.title, post.id}
     end
   end
 end


### PR DESCRIPTION
```elixir
defp post_selector(posts) do
    for post <- posts do
      {:"#{post.title}", post.id}
    end
  end
```

into:
```elixir
defp post_selector(posts) do
    for post <- posts do
      {post.title, post.id}
    end
  end
```