### PR TITLE
fix: Support LV 0.15

### DIFF
--- a/lib/ash_phoenix/live_view.ex
+++ b/lib/ash_phoenix/live_view.ex
@@ -600,6 +600,10 @@ defmodule AshPhoenix.LiveView do
           Phoenix.LiveView.assign(socket, one, two)
         end
       end
+    {:error, :nofile} ->
+      defp assign(%Phoenix.LiveView.Socket{} = socket, one, two) do
+        Phoenix.LiveView.assign(socket, one, two)
+      end
   end
 
   defp assign(socket, one, two) do


### PR DESCRIPTION
I'm updating a legacy app to use the latest Ash releases, but need to keep the old versions of phoenix, liveview, surface etc (I'm not ready to go down that rabbit hole just yet!).

ash_phoenix deps indicates that it supports live view 0.15, but I was getting a compile time error:

```
== Compilation error in file lib/ash_phoenix/live_view.ex ==
** (CaseClauseError) no case clause matching: {:error, :nofile}
    lib/ash_phoenix/live_view.ex:592: (module)
```

This PR fixes the issue and I can now compile modern Ash with legacy LiveView