### PR TITLE
Fixes default values on dead forms

### DIFF
--- a/lib/ash_phoenix/live_view.ex
+++ b/lib/ash_phoenix/live_view.ex
@@ -600,6 +600,7 @@ defmodule AshPhoenix.LiveView do
           Phoenix.LiveView.assign(socket, one, two)
         end
       end
+
     {:error, :nofile} ->
       defp assign(%Phoenix.LiveView.Socket{} = socket, one, two) do
         Phoenix.LiveView.assign(socket, one, two)

--- a/test/support/resources/post_with_default.ex
+++ b/test/support/resources/post_with_default.ex
@@ -13,5 +13,6 @@ defmodule AshPhoenix.Test.PostWithDefault do
   attributes do
     uuid_primary_key(:id)
     attribute(:text, :string, allow_nil?: false, default: "foo")
+    attribute(:title, :string)
   end
 end


### PR DESCRIPTION
Forms submitted outside of LiveView submit empty strings as params for empty fields. Empty fields are problematic for default values because "" is a value, and the resource won't set the default.

To allow the dead view forms, I have added a new
form option. `empty_fields_unset` takes a list of field names. The form will remove empty fields in the `empty_fields_unset` from the params map before the params are processed.

closes #52

### Contributor checklist

- [x] Bug fixes include regression tests
- [x] Features include unit/acceptance tests
