### PR TITLE
docs: Added setting post_selector in update_post

### DIFF
--- a/documentation/tutorials/getting-started-with-ash-and-phoenix.md
+++ b/documentation/tutorials/getting-started-with-ash-and-phoenix.md
@@ -471,7 +471,7 @@ defmodule MyAshPhoenixAppWeb.ExampleLiveView do
     post_id |> Post.get_by_id!() |> Post.update!(%{content: content})
     posts = Post.read_all!()
 
-    {:noreply, assign(socket, :posts, posts)}
+    {:noreply, assign(socket, posts: posts, post_selector: post_selector(posts))}
   end
 
   defp post_selector(posts) do


### PR DESCRIPTION
If we have a single post and update that post and do not set post_selector in update_post handle_event we will have the old post still selected.