### PR TITLE
Fix usage documentation

### DIFF
--- a/lib/ash_phoenix/plug/subdomain_plug.ex
+++ b/lib/ash_phoenix/plug/subdomain_plug.ex
@@ -29,7 +29,7 @@ defmodule AshPhoenix.SubdomainPlug do
   #{Spark.OptionsHelpers.docs(@plug_options)}
 
   To plug it on your router, you can use:
-      plug Ash.SubdomainPlug,
+      plug AshPhoenix.SubdomainPlug,
         endpoint: MyApp.Endpoint
 
   An additional helper here can be used for determining the host in your liveview, and/or using


### PR DESCRIPTION
I was going through implementing multi-tenancy in a Phoenix app and noticed the usage documentation had a typo in it. This PR should fix that. Thanks!