### PR TITLE
Fix return when form has error when handling phoenix form

### DIFF
--- a/lib/ash_phoenix/form/form.ex
+++ b/lib/ash_phoenix/form/form.ex
@@ -1436,7 +1436,7 @@ defmodule AshPhoenix.Form do
     |> submit(opts)
     |> case do
       {:error, new_form} ->
-        Phoenix.HTML.FormData.to_form(new_form, form.options)
+        {:error, Phoenix.HTML.FormData.to_form(new_form, form.options)}
 
       other ->
         other


### PR DESCRIPTION
Wrapped the error in an error tuple as was getting `** (CaseClauseError) no case clause matching: %Phoenix.HTML.Form{...}` when submit was invalid (when submitting a phoenix form, ie phx 1.18 only):

```elixir
    case AshPhoenix.Form.submit(socket.assigns.form, params: params) do
      ...
      {:error, form} ->
        {:noreply, assign(socket, form: form)}
    end

```