### PR TITLE
Fix: form_for deprecation warning

### DIFF
--- a/lib/ash_phoenix/filter_form/filter_form.ex
+++ b/lib/ash_phoenix/filter_form/filter_form.ex
@@ -930,7 +930,7 @@ defmodule AshPhoenix.FilterForm do
         impl: __MODULE__,
         id: opts[:id] || form.id,
         name: opts[:as] || form.name,
-        errors: [],
+        errors: opts[:errors] || [],
         data: form,
         params: form.params,
         hidden: hidden,
@@ -945,10 +945,21 @@ defmodule AshPhoenix.FilterForm do
       |> Enum.map(fn {component, index} ->
         name = Map.get(component, :name, phoenix_form.name)
 
-        Phoenix.HTML.Form.form_for(component, "action",
-          transform_errors: form.transform_errors,
-          as: name <> "[components][#{index}]"
-        )
+        case component do
+          %AshPhoenix.FilterForm{} ->
+            to_form(component,
+              as: name <> "[components][#{index}]",
+              id: component.id,
+              errors: AshPhoenix.FilterForm.errors(component)
+            )
+
+          %AshPhoenix.FilterForm.Predicate{} ->
+            Phoenix.HTML.FormData.AshPhoenix.FilterForm.Predicate.to_form(component,
+              as: name <> "[components][#{index}]",
+              id: component.id,
+              errors: AshPhoenix.FilterForm.errors(component)
+            )
+        end
       end)
     end
 


### PR DESCRIPTION
### Contributor checklist

Fixes a deprecation warning appearing when using latest phoenix:

```
warning: form_for/3 without an anonymous function is deprecated. If you are using Phoenix.LiveView, use the new Phoenix.Component.form/1 component
  (phoenix_html 3.3.1) lib/phoenix_html/form.ex:341: Phoenix.HTML.Form.form_for/3
  (elixir 1.14.3) lib/enum.ex:1658: Enum."-map/2-lists^map/1-0-"/2
  (phoenix_live_view 0.18.18) lib/phoenix_component.ex:2266: Phoenix.Component."inputs_for (overridable 1)"/1
  (phoenix_live_view 0.18.18) lib/phoenix_live_view/tag_engine.ex:68: Phoenix.LiveView.TagEngine.component/3
  (my_app 0.1.0) lib/my_app_web/live/filter_form_live.ex:65: anonymous fn/2 in MyAppWeb.FilterFormLive.filter_form_component/1
  (phoenix_live_view 0.18.18) lib/phoenix_live_view/diff.ex:517: Phoenix.LiveView.Diff.invoke_dynamic/2
  (phoenix_live_view 0.18.18) lib/phoenix_live_view/diff.ex:398: Phoenix.LiveView.Diff.traverse/7
  (phoenix_live_view 0.18.18) lib/phoenix_live_view/diff.ex:544: anonymous fn/4 in Phoenix.LiveView.Diff.traverse_dynamic/7
```

All existing tests are passing but... I'm not sure of the call to `Phoenix.HTML.FormData.AshPhoenix.FilterForm.Predicate.to_form()`, is this bad? I had to add this case statement as component could be either a group or a predicate, and I think the call to form_for was using the correct implementation.

Also, there are more calls to `form_for` without the anonymous function that probably will want to get updated (`AshPhoenix.FilterForm.Arguments` and `AshPhoenix.FilterForm.Predicates`). And in the tests too.