### PR TITLE
doc: Add the missing `action` argument to function call

### DIFF
--- a/lib/ash_phoenix/form/form.ex
+++ b/lib/ash_phoenix/form/form.ex
@@ -107,6 +107,7 @@ defmodule AshPhoenix.Form do
       |> MyApi.load!(comments: [:sub_comments])
 
     form = AshPhoenix.Form.for_update(post,
+      :update,
       api: MyApp.MyApi,
       forms: [
         comments: [


### PR DESCRIPTION
### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests


Fixes the documentation as specified in issue https://github.com/ash-project/ash_phoenix/issues/61