### PR TITLE
Fix remove_component

### DIFF
--- a/lib/ash_phoenix/filter_form/filter_form.ex
+++ b/lib/ash_phoenix/filter_form/filter_form.ex
@@ -903,11 +903,11 @@ defmodule AshPhoenix.FilterForm do
     |> set_validity()
   end
 
-  @doc "Removes the group *or* component with the given id"
-  def remove_component(form, group_or_component_id) do
+  @doc "Removes the group *or* predicate with the given id"
+  def remove_component(form, group_or_predicate_id) do
     form
-    |> remove_group(group_or_component_id)
-    |> remove_component(group_or_component_id)
+    |> remove_group(group_or_predicate_id)
+    |> remove_predicate(group_or_predicate_id)
   end
 
   defp remove_if_empty(form, false), do: [form]

--- a/test/filter_form_test.exs
+++ b/test/filter_form_test.exs
@@ -61,7 +61,7 @@ defmodule AshPhoenix.FilterFormTest do
              } = form
     end
 
-    test "group and predicates can be removed with remove_component" do
+    test "groups and predicates can be removed with remove_component" do
       form = FilterForm.new(Post)
 
       {form, group_id} = FilterForm.add_group(form, operator: :or, return_id?: true)

--- a/test/filter_form_test.exs
+++ b/test/filter_form_test.exs
@@ -61,6 +61,31 @@ defmodule AshPhoenix.FilterFormTest do
              } = form
     end
 
+    test "group and predicates can be removed with remove_component" do
+      form = FilterForm.new(Post)
+
+      {form, group_id} = FilterForm.add_group(form, operator: :or, return_id?: true)
+
+      {form, predicate_id} =
+        FilterForm.add_predicate(form, :title, :eq, "new post", to: group_id, return_id?: true)
+
+      form = FilterForm.remove_component(form, predicate_id)
+
+      assert %FilterForm{
+               components: [
+                 %FilterForm{
+                   components: []
+                 }
+               ]
+             } = form
+
+      form = FilterForm.remove_component(form, group_id)
+
+      assert %FilterForm{
+               components: []
+             } = form
+    end
+
     test "with `remove_empty_groups?: true` empty groups are removed on component removal" do
       form = FilterForm.new(Post, remove_empty_groups?: true)
 


### PR DESCRIPTION
I'm guessing this is the intended behaviour of remove_component? ie to remove either the group or predicate, not to recursively call remove_component?
