### PR TITLE
fix: fix Logger deprecations for elixir 1.15

### DIFF
--- a/lib/ash_phoenix/form_data/helpers.ex
+++ b/lib/ash_phoenix/form_data/helpers.ex
@@ -68,7 +68,7 @@ defmodule AshPhoenix.FormData.Helpers do
         match?
       else
         if form.warn_on_unhandled_errors? do
-          Logger.warn("""
+          Logger.warning("""
           Unhandled error in form submission for #{inspect(form.resource)}.#{form.action}
 
           This error was unhandled because it did not have a `path` key.
@@ -107,7 +107,7 @@ defmodule AshPhoenix.FormData.Helpers do
           true
         else
           if form.warn_on_unhandled_errors? do
-            Logger.warn("""
+            Logger.warning("""
             Unhandled error in form submission for #{inspect(form.resource)}.#{form.action}
 
             This error was unhandled because it did not implement the `AshPhoenix.FormData.Error` protocol.
@@ -127,7 +127,7 @@ defmodule AshPhoenix.FormData.Helpers do
 
       error ->
         if form.warn_on_unhandled_errors? do
-          Logger.warn("""
+          Logger.warning("""
           Unhandled error in form submission for #{form.resource}.#{form.action}
 
           This error was unhandled because it was not an exception that implemented the `AshPhoenix.FormData.Error`

--- a/mix.exs
+++ b/mix.exs
@@ -12,7 +12,7 @@ defmodule AshPhoenix.MixProject do
       app: :ash_phoenix,
       version: @version,
       description: @description,
-      elixir: "~> 1.9",
+      elixir: "~> 1.11",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       elixirc_paths: elixirc_paths(Mix.env()),


### PR DESCRIPTION
Use Logger.warning instead of Logger.warn, [which is deprecated as of elixir 1.15](https://github.com/elixir-lang/elixir/blob/v1.15/CHANGELOG.md#logger-2).

Logger.warning [is available since elixir 1.11](https://hexdocs.pm/logger/1.15.0/Logger.html#warning/2). This project has been updated to require at least elixir 1.11. This should be fine, since `ash` and the other ash ecosystem projects all also require elixir 1.11.
