### PR TITLE
Documentation. Add `|> to_form()` to the end of the pipeline for Liveview >= 1.18.2

### DIFF
--- a/lib/ash_phoenix/form/form.ex
+++ b/lib/ash_phoenix/form/form.ex
@@ -35,6 +35,7 @@ defmodule AshPhoenix.Form do
       api: MyApi,
       forms: [auto?: true]
       ])
+    |> to_form()
   ```
 
   2. Explicitly configure the behavior of it using the `forms` option. See `for_create/3` for more.
@@ -62,6 +63,7 @@ defmodule AshPhoenix.Form do
           ]
         ]
       ])
+    |> to_form()
   ```
 
   ## LiveView


### PR DESCRIPTION
Tiny documentation change to make it work in modern versions of LiveView.
