### PR TITLE
Suggest Atom plural value 👯‍♂️

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -16,7 +16,7 @@ A minimal set of resource definitions and calls that can reproduce the bug.
 **Expected behavior**
 A clear and concise description of what you expected to happen.
 
-** Runtime
+**Runtime**
  - Elixir version
  - Erlang version
  - OS

--- a/lib/ash_phoenix/gen/live.ex
+++ b/lib/ash_phoenix/gen/live.ex
@@ -346,7 +346,7 @@ defmodule AshPhoenix.Gen.Live do
           You can press enter to abort, and then configure one on the resource, for example:
 
               resource do
-                plural_name "tweets"
+                plural_name :tweets
               end
           >
           """


### PR DESCRIPTION
I believe we need to use an Atom value.

When I tried to use a String I got the following error:

```
(Spark.Error.DslError) [Red.Api.Attempt]
 resource:
  ** (NimbleOptions.ValidationError) invalid value for :plural_name option: expected atom, got: "attempts"
```