### PR TITLE
fix: errors messages on embedded forms multiply 

### DIFF
--- a/lib/ash_phoenix/form/form.ex
+++ b/lib/ash_phoenix/form/form.ex
@@ -3509,8 +3509,7 @@ defmodule AshPhoenix.Form do
       |> Enum.map(fn error ->
         %{error | path: trail ++ error.path}
       end)
-
-    further_errors = further_errors ++ Enum.reject(errors, &(&1.path == trail))
+      |> Enum.filter(&(&1.path == trail))
 
     new_forms =
       form.forms
@@ -3525,12 +3524,12 @@ defmodule AshPhoenix.Form do
               synthesize_action_errors(
                 form,
                 trail ++ [config[:for] || key, index],
-                further_errors
+                errors
               )
             end)
           else
             if forms do
-              synthesize_action_errors(forms, trail ++ [config[:for] || key], further_errors)
+              synthesize_action_errors(forms, trail ++ [config[:for] || key], errors)
             end
           end
 


### PR DESCRIPTION
The `Enum.uniq()` on error messages does address my initial bug, but I believe this fixes it at the source. When `Ash.phoenix_form.synthesize_action_errors/3` is called recursively, the embedded form errors are added twice. This fixes the issue for me without the need for `Enum.uniq()` in the helper. My robust test suite passes and I did some manual testing in my app, but I don't know if this "fix" is appropriate for everyone.

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
