### PR TITLE
Remove multiple attribute from select for one_of fields

### DIFF
--- a/lib/ash_phoenix/gen/live.ex
+++ b/lib/ash_phoenix/gen/live.ex
@@ -377,7 +377,6 @@ defmodule AshPhoenix.Gen.Live do
                 <.input
                 field={@form[#{inspect(field.name)}]}
                 type="select"
-                multiple
                 label="#{label(field.name)}"
                 options={Ash.Resource.Info.attribute(#{inspect(resource)}, #{inspect(field.name)}).constraints[:one_of]}
                 />


### PR DESCRIPTION
This removes the 'multiple' attribute from the select input in case the field is an atom field with the `one_of` option set.

Solves: #114

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
