### PR TITLE
Update filter form documentation for LiveView 0.19

### DIFF
--- a/lib/ash_phoenix/filter_form/filter_form.ex
+++ b/lib/ash_phoenix/filter_form/filter_form.ex
@@ -75,19 +75,19 @@ defmodule AshPhoenix.FilterForm do
         <div class="flex flex-row gap-2 items-center">Filter</div>
         <div class="flex flex-row gap-2 items-center">
           <.input type="select" field={@component[:operator]} options={["and", "or"]} />
-          <.button phx-click="add_filter_group" phx-value-component-id={@component.id} type="button">
+          <.button phx-click="add_filter_group" phx-value-component-id={@component.source.id} type="button">
             Add Group
           </.button>
           <.button
             phx-click="add_filter_predicate"
-            phx-value-component-id={@component.id}
+            phx-value-component-id={@component.source.id}
             type="button"
           >
             Add Predicate
           </.button>
           <.button
             phx-click="remove_filter_component"
-            phx-value-component-id={@component.id}
+            phx-value-component-id={@component.source.id}
             type="button"
           >
             Remove Group
@@ -119,7 +119,7 @@ defmodule AshPhoenix.FilterForm do
       <.input field={@component[:value]} />
       <.button
         phx-click="remove_filter_component"
-        phx-value-component-id={@component.id}
+        phx-value-component-id={@component.source.id}
         type="button"
       >
         Remove


### PR DESCRIPTION
The example given for FilterForm worked with LiveView 0.18 but was broken for 0.19. I'm a bit out of the loop with LiveView, but the change here seems to work.

See https://elixirforum.com/t/ashphoenix-filterform-cannot-remove-components/59630