### PR TITLE
Nested form errors for argument attribute

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,5 @@
+image: elixir:latest
+  
+tasks:
+  - init: mix deps.get && mix compile
+    command: iex -S mix

--- a/test/support/resources/author.ex
+++ b/test/support/resources/author.ex
@@ -13,6 +13,14 @@ defmodule AshPhoenix.Test.Author do
 
   actions do
     defaults([:create, :read, :update])
+
+    update :update_with_embedded_argument do
+      # This an empty change, just so test how we handle errors on embedded arguments
+      accept []
+      argument :embedded_argument, AshPhoenix.Test.EmbeddedArgument, allow_nil?: false
+
+      validate { AshPhoenix.Test.ValidateEmbeddedArgument, [] }
+    end
   end
 
   relationships do

--- a/test/support/resources/embedded_argument.ex
+++ b/test/support/resources/embedded_argument.ex
@@ -1,0 +1,8 @@
+defmodule AshPhoenix.Test.EmbeddedArgument do
+  @moduledoc false
+  use Ash.Resource, data_layer: :embedded
+
+  attributes do
+    attribute :value, :string
+  end
+end

--- a/test/support/validations/validate_embedded_argument.ex
+++ b/test/support/validations/validate_embedded_argument.ex
@@ -1,0 +1,44 @@
+defmodule AshPhoenix.Test.ValidateEmbeddedArgument do
+  @moduledoc """
+  This is a contrived example, but we want to validate one or more arguments' attributes
+  against an attribute on the parent resource and then put an error on the
+  changeset that will get propogated down to the nest form for the embedded argument.
+  """
+
+  use Ash.Resource.Validation
+
+  # This is the name of our embedded argument
+  @embedded_argument :embedded_argument
+
+  # This is the name of the attribute on the embedded argument
+  @embedded_attribute :value
+
+  @impl true
+  def validate(changeset, _opts) do
+    case Ash.Changeset.get_argument(changeset, @embedded_argument) do
+      nil ->
+        :ok
+
+      argument ->
+        apply_validation(changeset, argument)
+    end
+  end
+
+  def apply_validation(changeset, argument) do
+    email = Ash.Changeset.get_attribute(changeset, :email)
+    value = Map.get(argument, @embedded_attribute)
+
+    if value == email do
+      :ok
+    else
+      {:error,
+        Ash.Error.Changes.InvalidArgument.exception(
+          field: @embedded_attribute,
+          message: "must match email",
+          value: value,
+          path: [@embedded_argument]
+        )
+      }
+    end
+  end
+end


### PR DESCRIPTION
This may be an X/Y problem, but what I'm trying to do is have an action with an argument that is an embedded resource. The argument resource itself may be valid, but in the context of the parent it is invalid, so the parent creates an add an error with the path to the arguments attribute. That error is not being propagated to the nested form of the argument.

This is a test to reproduce the problem.

Discussed here:
https://elixirforum.com/t/setting-path-on-an-error/59857/3

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
