### PR TITLE
Nested form errors should not multiply

### DIFF
--- a/test/support/resources/embedded_argument.ex
+++ b/test/support/resources/embedded_argument.ex
@@ -4,5 +4,6 @@ defmodule AshPhoenix.Test.EmbeddedArgument do
 
   attributes do
     attribute :value, :string
+    attribute :nested_embeds, {:array, AshPhoenix.Test.NestedEmbed}, default: []
   end
 end

--- a/test/support/resources/nested_embed.ex
+++ b/test/support/resources/nested_embed.ex
@@ -1,0 +1,13 @@
+defmodule AshPhoenix.Test.NestedEmbed do
+  @moduledoc false
+  use Ash.Resource, data_layer: :embedded
+
+  attributes do
+    attribute :limit, :integer, allow_nil?: false
+    attribute :four_chars, :string, allow_nil?: false
+  end
+
+  validations do
+    validate string_length(:four_chars, exact: 4)
+  end
+end


### PR DESCRIPTION
As discussed in Discord, error message on nested form changeset multiply when turned into a Phoenix Form

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
