### PR TITLE
Fix `do_decode_path` for string paths

### DIFF
--- a/lib/ash_phoenix/form/form.ex
+++ b/lib/ash_phoenix/form/form.ex
@@ -3674,7 +3674,7 @@ defmodule AshPhoenix.Form do
   defp do_decode_path(_, _, [], _), do: []
 
   defp do_decode_path([], original_path, _, _) do
-    raise "Invalid Path: #{original_path}"
+    raise InvalidPath, path: original_path
   end
 
   defp do_decode_path(forms, original_path, [key | rest], sparse?) when is_list(forms) do
@@ -3691,7 +3691,7 @@ defmodule AshPhoenix.Form do
 
         case matching_form do
           nil ->
-            raise "Invalid Path: #{original_path}"
+            raise InvalidPath, path: original_path
 
           form ->
             case Enum.at(rest, 0) do
@@ -3711,7 +3711,7 @@ defmodule AshPhoenix.Form do
         end
 
       _ ->
-        raise "Invalid Path: #{original_path}"
+        raise InvalidPath, path: original_path
     end
   end
 
@@ -3724,7 +3724,7 @@ defmodule AshPhoenix.Form do
     end)
     |> case do
       nil ->
-        raise "Invalid Path: #{original_path}"
+        raise InvalidPath, path: original_path
 
       {key, config} ->
         if Keyword.get(config, :type, :single) == :single do

--- a/test/form_test.exs
+++ b/test/form_test.exs
@@ -196,6 +196,10 @@ defmodule AshPhoenix.FormTest do
 
       # assert Form.has_form?(form, [:comments])
       assert Form.has_form?(form, [:comments, 0])
+      assert Form.has_form?(form, "form[comments][0]")
+
+      refute Form.has_form?(form, [:comments, 1])
+      refute Form.has_form?(form, "form[comments][1]")
     end
 
     test "checks for the existence of a single form" do
@@ -213,10 +217,12 @@ defmodule AshPhoenix.FormTest do
         |> Form.add_form([:post])
 
       assert Form.has_form?(form, [:post])
+      assert Form.has_form?(form, "form[post]")
+
       refute Form.has_form?(form, [:unknown])
+      refute Form.has_form?(form, "form[unknown]")
     end
   end
-
 
   describe "form_for fields" do
     test "it should show simple field values" do

--- a/test/form_test.exs
+++ b/test/form_test.exs
@@ -178,6 +178,46 @@ defmodule AshPhoenix.FormTest do
     end
   end
 
+  describe "has_form?" do
+    test "checks for the existence of a list of forms" do
+      form =
+        Post
+        |> Form.for_create(:create,
+          api: Api,
+          forms: [
+            comments: [
+              type: :list,
+              resource: Comment,
+              create_action: :create
+            ]
+          ]
+        )
+        |> Form.add_form([:comments])
+
+      # assert Form.has_form?(form, [:comments])
+      assert Form.has_form?(form, [:comments, 0])
+    end
+
+    test "checks for the existence of a single form" do
+      form =
+        Comment
+        |> Form.for_create(:create,
+          forms: [
+            post: [
+              type: :single,
+              resource: Post,
+              create_action: :create
+            ]
+          ]
+        )
+        |> Form.add_form([:post])
+
+      assert Form.has_form?(form, [:post])
+      refute Form.has_form?(form, [:unknown])
+    end
+  end
+
+
   describe "form_for fields" do
     test "it should show simple field values" do
       form =


### PR DESCRIPTION
`AshPhoenix.Form.has_form?` fails when given a string path. 

![image](https://github.com/ash-project/ash_phoenix/assets/28830783/871605b9-b434-472d-ad5a-454a7f4cacdc)


This happens because the `do_decode_path` functions `raise "Invalid Path: #{original_path}"` instead of `raise InvalidPath, path: original_path`.  The calling functions, however, expect to rescue an `InvalidPath` exception.

This PR:
- switches from raising strings to raising `InvalidPath` exceptions
- adds regression tests

### Contributor checklist

- [x] Bug fixes include regression tests

