### PR TITLE
fix: properly fetch refetch_window from config

### DIFF
--- a/lib/ash_phoenix/live_view.ex
+++ b/lib/ash_phoenix/live_view.ex
@@ -440,7 +440,7 @@ defmodule AshPhoenix.LiveView do
       requested_before_last_refetch? ->
         socket
 
-      config[:refetch_window] && diff < config[:refetch_window] ->
+      config.opts[:refetch_window] && diff < config.opts[:refetch_window] ->
         Process.send_after(
           self(),
           {:refetch, assign, [requested_at: System.monotonic_time(:millisecond)]},


### PR DESCRIPTION
refetch_window is currently being fetched from config directly instead of opts inside config, which causes handle_live to always ignore refetch_window and just rerun the query regardless. 

This PR fixes that.