### PR TITLE
When adding deeply nested form with params, generated form name is not correct

### DIFF
--- a/test/form_test.exs
+++ b/test/form_test.exs
@@ -1762,6 +1762,38 @@ defmodule AshPhoenix.FormTest do
 
       assert form.valid? == true
     end
+
+    test "add form with nested params generate form with correct name" do
+      post_id = Ash.UUID.generate()
+      comment_id = Ash.UUID.generate()
+
+      comment = %Comment{
+        text: "text",
+        post: %Post{
+          id: post_id,
+          text: "Some text",
+          comments: [%Comment{id: comment_id}]
+        }
+      }
+
+      form =
+        comment
+        |> Form.for_update(:update, as: "comment", forms: [auto?: true])
+        |> Form.add_form([:post])
+        |> Form.add_form([:post, :comments], params: %{"post" => %{}})
+
+      post_form =
+        form
+        |> form_for("action")
+        |> inputs_for(:post)
+        |> hd()
+        |> inputs_for(:comments)
+        |> hd()
+        |> inputs_for(:post)
+        |> hd()
+
+      assert post_form.name == "comment[post][comments][0][post]"
+    end
   end
 
   describe "issue #259" do


### PR DESCRIPTION
I just added a failing test.
Would you fix this? @zachdaniel 

+ If possible, please fix the ash phoenix version 1.3.4 too, not only 2.0 rc.