### PR TITLE
Remove domain opt from AshPhoenix.LiveView

### DIFF
--- a/lib/ash_phoenix/live_view.ex
+++ b/lib/ash_phoenix/live_view.ex
@@ -38,11 +38,6 @@ defmodule AshPhoenix.LiveView do
       type: :any,
       doc: "Results to use instead of running the query immediately."
     ],
-    domain: [
-      type: :atom,
-      doc:
-        "For paginated views, in order to use `change_page/3`, you must set the Domain to use for pagination"
-    ],
     refetch_interval: [
       type: :non_neg_integer,
       doc: "An interval (in ms) to periodically refetch the query"
@@ -219,11 +214,7 @@ defmodule AshPhoenix.LiveView do
         data -> data
       end
 
-    unless config.opts[:domain] do
-      raise "Must set domain to use change_page/3"
-    end
-
-    new_result = config.opts[:domain].page!(current_page, target)
+    new_result = Ash.page!(current_page, target)
     {_query, rerun_opts} = new_result.rerun
     new_page_opts = Keyword.merge(config.opts[:page] || [], rerun_opts[:page])
     new_opts = Keyword.put(config.opts, :page, new_page_opts)


### PR DESCRIPTION
### Contributor checklist

- [ ] Bug fixes include regression tests
- [x] Features include unit/acceptance tests

It's a chore PR that removes `domain` opt from `AshPhoenix.LiveView`.
