### PR TITLE
docs: Fix typo in Getting Started guide

### DIFF
--- a/documentation/tutorials/getting-started-with-ash-and-phoenix.md
+++ b/documentation/tutorials/getting-started-with-ash-and-phoenix.md
@@ -136,7 +136,7 @@ defmodule MyAshPhoenixApp.Blog do
   resources do
     resource MyAshPhoenixApp.Blog.Post do
       # Define an interface for calling resource actions.
-      define :create_posts, action: :create
+      define :create_post, action: :create
       define :list_posts, action: :read
       define :update_post, action: :update
       define :destroy_post, action: :destroy


### PR DESCRIPTION
The rest of the guide refers to `create_post` in the singular, so that is what the code interface function should be named

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
