### PR TITLE
fix: Convert entered action names into atoms for lookup in the resource

### DIFF
--- a/lib/ash_phoenix/gen/live.ex
+++ b/lib/ash_phoenix/gen/live.ex
@@ -239,7 +239,7 @@ defmodule AshPhoenix.Gen.Live do
               nil
 
             action ->
-              action(resource, Keyword.put(opts, :"#{type}_action", action), type)
+              action(resource, Keyword.put(opts, :"#{type}_action", String.to_atom(action)), type)
           end
         else
           if Mix.shell().yes?("Would you like to create one?") do


### PR DESCRIPTION
When generating live templates with `mix ash_phoenix.gen.live`, the user is prompted to enter an action name for create and update. When a string is entered, an error occurs because lookups are done via atom, not string.

```
Primary create action not found. Would you like to use one of the following?:
- create [Yn]
Please enter the name of the action you would like to use.
Press enter to cancel and proceed with no create action.
> create
** (RuntimeError) No such create action "create"
    (ash_phoenix 2.0.0) lib/ash_phoenix/gen/live.ex:198: AshPhoenix.Gen.Live.action/3
    (ash_phoenix 2.0.0) lib/ash_phoenix/gen/live.ex:162: AshPhoenix.Gen.Live.add_resource_assigns/3
```

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
