### PR TITLE
fix: make sure that _index is correctly updated before and after removal for sparse forms (#196)

### DIFF
--- a/lib/ash_phoenix/form/form.ex
+++ b/lib/ash_phoenix/form/form.ex
@@ -3315,6 +3315,7 @@ defmodule AshPhoenix.Form do
               nested_form
               | name: new_name,
                 id: new_id,
+                params: add_index(nested_form.params, i, form.opts[:forms][key]),
                 forms:
                   replace_form_names(
                     nested_form.forms,
@@ -4025,7 +4026,7 @@ defmodule AshPhoenix.Form do
         matching_form =
           if sparse? do
             Enum.find(forms, fn form ->
-              form.params["_index"] == key
+              form.params["_index"] == to_string(key)
             end)
           else
             Enum.at(forms, index)
@@ -4224,6 +4225,7 @@ defmodule AshPhoenix.Form do
                     actor: actor,
                     tenant: tenant,
                     errors: error?,
+                    params: add_index(params, index, opts),
                     accessing_from: opts[:managed_relationship],
                     prepare_source: opts[:prepare_source],
                     warn_on_unhandled_errors?: warn_on_unhandled_errors?,

--- a/test/form_test.exs
+++ b/test/form_test.exs
@@ -1583,6 +1583,54 @@ defmodule AshPhoenix.FormTest do
       assert form_1.id == "form_posts_1"
     end
 
+    test "sparse forms can also be removed by index" do
+      post1_id = Ash.UUID.generate()
+      post2_id = Ash.UUID.generate()
+      post3_id = Ash.UUID.generate()
+
+      comment = %Comment{
+        text: "text",
+        post: [%Post{id: post1_id}, %Post{id: post2_id}, %Post{id: post3_id}]
+      }
+
+      form =
+        comment
+        |> Form.for_update(:update,
+          forms: [
+            posts: [
+              data: comment.post,
+              type: :list,
+              resource: Post,
+              create_action: :create,
+              update_action: :update,
+              sparse?: true
+            ]
+          ]
+        )
+        |> Form.remove_form([:posts, 1])
+
+      assert [
+               %Phoenix.HTML.Form{source: %AshPhoenix.Form{resource: AshPhoenix.Test.Post}} =
+                 form_0,
+               %Phoenix.HTML.Form{source: %AshPhoenix.Form{resource: AshPhoenix.Test.Post}} =
+                 form_1
+             ] = inputs_for(form_for(form, "action"), :posts)
+
+      assert form_0.name == "form[posts][0]"
+      assert form_0.id == "form_posts_0"
+
+      assert form_1.name == "form[posts][1]"
+      assert form_1.id == "form_posts_1"
+
+      form =
+        form
+        |> Form.remove_form([:posts, 1])
+
+      assert [
+               %Phoenix.HTML.Form{source: %AshPhoenix.Form{resource: AshPhoenix.Test.Post}}
+             ] = inputs_for(form_for(form, "action"), :posts)
+    end
+
     test "when `:single`, `inputs_for` generates a list of one single item" do
       post_id = Ash.UUID.generate()
       comment = %Comment{text: "text", post: %Post{id: post_id, text: "Some text"}}


### PR DESCRIPTION
### Contributor checklist

- [x] Bug fixes include regression tests
- [x] Features include unit/acceptance tests
