### PR TITLE
type wrapper

### DIFF
--- a/test/form_test.exs
+++ b/test/form_test.exs
@@ -58,6 +58,18 @@ defmodule AshPhoenix.FormTest do
                "Unhandled error in form submission for AshPhoenix.Test.Comment.create_with_unknown_error"
     end
 
+    test "empty atom field" do
+      form =
+        Post
+        |> Form.for_create(:create,
+          domain: Domain,
+          params: %{}
+        )
+        |> Form.submit!(
+          params: %{"inline_atom_field" => "", "custom_atom_field" => "", "text" => "text"}
+        )
+    end
+
     test "update_form marks touched by default" do
       form =
         Post

--- a/test/support/resources/atom_type.ex
+++ b/test/support/resources/atom_type.ex
@@ -1,0 +1,3 @@
+defmodule AshPhoenix.Test.Action do
+  use Ash.Type.NewType, subtype_of: :atom
+end

--- a/test/support/resources/post.ex
+++ b/test/support/resources/post.ex
@@ -16,6 +16,8 @@ defmodule AshPhoenix.Test.Post do
     attribute(:union_array, {:array, AshPhoenix.Test.UnionValue}, public?: true)
     attribute(:list_of_ints, {:array, :integer}, public?: true)
     attribute(:title, :string, public?: true)
+    attribute(:inline_atom_field, :atom, public?: true)
+    attribute(:custom_atom_field, AshPhoenix.Test.Action, public?: true)
   end
 
   actions do


### PR DESCRIPTION
If field has type :atom and in form field is empty, and another field is changed, validate works properly, but if i have type:

```elixir
defmodule AshPhoenix.Test.Action do
  use Ash.Type.NewType, subtype_of: :atom
end
```
and i use it for attribute `attribute(:custom_atom_field, AshPhoenix.Test.Action, public?: true)` and field is empty and another field gets changed, validate fails with:
```
[error] GenServer #PID<0.1775.0> terminating
** (CaseClauseError) no case clause matching: :ok
    (ash 3.0.10) lib/ash/type/type.ex:743: Ash.Type.cast_input/3
    (ash_phoenix 2.0.3) lib/ash_phoenix/form/wrapped_value.ex:35: AshPhoenix.Form.WrappedValue.change_0_generated_AC5F836547B8DDEDB23A9C30C822D686/2
    (ash 3.0.10) lib/ash/changeset/changeset.ex:2196: anonymous fn/6 in Ash.Changeset.run_action_changes/6
    (elixir 1.16.2) lib/enum.ex:2528: Enum."-reduce/3-lists^foldl/2-0-"/3
    (ash 3.0.10) lib/ash/changeset/changeset.ex:2125: Ash.Changeset.run_action_changes/6
    (ash 3.0.10) lib/ash/changeset/changeset.ex:1630: Ash.Changeset.do_for_action/4
    (ash_phoenix 2.0.3) lib/ash_phoenix/form/form.ex:529: AshPhoenix.Form.for_create/3
    (ash_phoenix 2.0.3) lib/ash_phoenix/form/form.ex:4624: AshPhoenix.Form.handle_form_with_params/15
    (elixir 1.16.2) lib/enum.ex:2528: Enum."-reduce/3-lists^foldl/2-0-"/3
    (ash_phoenix 2.0.3) lib/ash_phoenix/form/form.ex:506: AshPhoenix.Form.for_create/3
    (ash_phoenix 2.0.3) lib/ash_phoenix/form/form.ex:5093: anonymous fn/14 in AshPhoenix.Form.handle_form_with_params_and_data/13
    (elixir 1.16.2) lib/enum.ex:2528: Enum."-reduce/3-lists^foldl/2-0-"/3
    (ash_phoenix 2.0.3) lib/ash_phoenix/form/form.ex:4955: AshPhoenix.Form.handle_form_with_params_and_data/13
    (ash_phoenix 2.0.3) lib/ash_phoenix/form/form.ex:4624: AshPhoenix.Form.handle_form_with_params/15
    (elixir 1.16.2) lib/enum.ex:2528: Enum."-reduce/3-lists^foldl/2-0-"/3
    (ash_phoenix 2.0.3) lib/ash_phoenix/form/form.ex:506: AshPhoenix.Form.for_create/3
    (ash_phoenix 2.0.3) lib/ash_phoenix/form/form.ex:1289: anonymous fn/9 in AshPhoenix.Form.validate_nested_forms/6
    (elixir 1.16.2) lib/enum.ex:2528: Enum."-reduce/3-lists^foldl/2-0-"/3
    (ash_phoenix 2.0.3) lib/ash_phoenix/form/form.ex:1269: anonymous fn/7 in AshPhoenix.Form.validate_nested_forms/6
    (elixir 1.16.2) lib/enum.ex:2528: Enum."-reduce/3-lists^foldl/2-0-"/3
```

