### PR TITLE
Use :public? instead of :private?

### DIFF
--- a/lib/mix/tasks/ash_phoenix.gen.html.ex
+++ b/lib/mix/tasks/ash_phoenix.gen.html.ex
@@ -157,7 +157,7 @@ defmodule Mix.Tasks.AshPhoenix.Gen.Html do
       name: attr.name,
       type: attr.type,
       writable?: Map.get(attr, :writable?, true),
-      private?: attr.private?
+      public?: attr.public?
     }
   end
 end


### PR DESCRIPTION
### Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests

This PR fixes an issue where trying to execute the command `mix ash_phoenix.gen.html` with Ash Framework 3.0.

Since Ash Framework 3.0, `:private?` has been replaced with `:public?`.

Here the error I got while running the command:
```
** (KeyError) key :private? not found in: %Ash.Resource.Attribute{
  name: :isbn,
  type: Ash.Type.String,
  allow_nil?: false,
  generated?: false,
  primary_key?: false,
  public?: true,
  writable?: true,
  always_select?: false,
  default: nil,
  update_default: nil,
  description: nil,
  source: :isbn,
  match_other_defaults?: false,
  sensitive?: false,
  filterable?: true,
  sortable?: true,
  constraints: [allow_empty?: false, trim?: true]
}
    (ash_phoenix 2.0.4) lib/mix/tasks/ash_phoenix.gen.html.ex:160: Mix.Tasks.AshPhoenix.Gen.Html.attribute_map/1
    (elixir 1.16.3) lib/enum.ex:1700: Enum."-map/2-lists^map/1-1-"/2
    (ash_phoenix 2.0.4) lib/mix/tasks/ash_phoenix.gen.html.ex:74: Mix.Tasks.AshPhoenix.Gen.Html.assigns/3
    (ash_phoenix 2.0.4) lib/mix/tasks/ash_phoenix.gen.html.ex:46: Mix.Tasks.AshPhoenix.Gen.Html.run/1
    (mix 1.16.3) lib/mix/task.ex:478: anonymous fn/3 in Mix.Task.run_task/5
    (mix 1.16.3) lib/mix/cli.ex:96: Mix.CLI.run_task/2
    /usr/local/bin/mix:2: (file)
``` 
