### PR TITLE
docs: remove duplicate mention of AshPhoenix.SubdomainPlug

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ Add `ash_phoenix` to your list of dependencies in `mix.exs`:
 - `AshPhoenix.SubdomainPlug` - A plug to determine a tenant using subdomains for multitenancy
 - `AshPhoenix.FormData.Error` - A protocol to allow errors to be rendered in forms
 - `Phoenix.HTML.Safe` implementations for `Ash.CiString`, `Ash.NotLoaded` and `Decimal`
-- `AshPhoenix.SubdomainPlug` for multitenant subdomain-based applications.
 - `mix ash_phoenix.gen.live` for generating liveview modules
 - `mix ash_phoenix.gen.html` for generating controllers and views
 


### PR DESCRIPTION
I noticed that `AshPhoenix.SubdomainPlug` was mentioned twice. Would it make sense to remove the less descriptive one?

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
