### PR TITLE
test: validate relationships after action changes

### DIFF
--- a/test/auto_form_test.exs
+++ b/test/auto_form_test.exs
@@ -435,6 +435,16 @@ defmodule AshPhoenix.AutoFormTest do
         |> AshPhoenix.Form.submit!()
       end
     end
+
+    test "should validate relationships after action changes" do
+      assert Post
+             |> AshPhoenix.Form.for_create(:create_with_default_comment, forms: [auto?: true])
+             |> AshPhoenix.Form.validate(%{
+               "text" => "text",
+               "comment" => %{}
+             })
+             |> AshPhoenix.Form.submit!()
+    end
   end
 
   defp auto_forms(resource, action) do

--- a/test/support/resources/post.ex
+++ b/test/support/resources/post.ex
@@ -40,6 +40,24 @@ defmodule AshPhoenix.Test.Post do
       change(manage_relationship(:comment_ids, :comments, type: :append_and_remove))
     end
 
+    create :create_with_default_comment do
+      accept :*
+      argument :comment, :map
+
+      change fn cs, _ ->
+        case Ash.Changeset.get_argument(cs, :comment) do
+          nil ->
+            cs
+
+          comment ->
+            comment = comment |> Map.put_new("text", "default")
+            Ash.Changeset.set_argument(cs, :comment, comment)
+        end
+      end
+
+      change manage_relationship(:comment, :comments, type: :create)
+    end
+
     create :create_author_required do
       argument(:author, :map, allow_nil?: false)
       change(manage_relationship(:author, type: :direct_control, on_missing: :unrelate))


### PR DESCRIPTION
Didn't fix the bug.
I just wrote a simple failing test.

In `create_with_default_comment` action, I am setting default value of comment text attribute.
However, because of the order of validations, this form cannot be submitted.