### PR TITLE
fix warning in filter_form.ex

### DIFF
--- a/lib/ash_phoenix/filter_form/filter_form.ex
+++ b/lib/ash_phoenix/filter_form/filter_form.ex
@@ -914,7 +914,7 @@ defmodule AshPhoenix.FilterForm do
     |> Enum.concat(Ash.Filter.builtin_functions())
     |> Enum.filter(fn function ->
       try do
-        struct(function).__predicate__? && Enum.any?(function.args, &match?([_, _], &1))
+        struct(function).__predicate__?() && Enum.any?(function.args, &match?([_, _], &1))
       rescue
         _ -> false
       end


### PR DESCRIPTION
```elixir
warning: using map.field notation (without parentheses) to invoke function AshPostgres.Functions.Like.args() is deprecated, you must add parentheses instead: remote.function()
  (ash_phoenix 2.1.12) lib/ash_phoenix/filter_form/filter_form.ex:917: anonymous fn/1 in AshPhoenix.FilterForm.predicates/1
```