### PR TITLE
Implement AshPhoenix.FormData.Error for Ash.Error.Changes.StaleRecord

### DIFF
--- a/lib/ash_phoenix/form_data/error.ex
+++ b/lib/ash_phoenix/form_data/error.ex
@@ -117,3 +117,10 @@ defimpl AshPhoenix.FormData.Error, for: Ash.Error.Query.Required do
     {error.field, "is required", error.vars}
   end
 end
+
+defimpl AshPhoenix.FormData.Error, for: Ash.Error.Changes.StaleRecord do
+  def to_form_error(error) do
+    {error.field, "is stale", error.vars}
+  end
+end
+


### PR DESCRIPTION
I did not see tests for the other errors.

I used it locally, and it worked, however since `field` is `nil` from `Ash.Error.Changes.StaleRecord` nothing is shown to the user in the UI. Not sure how to address this, other than anyone using optimistic locks just needs to know to handle it?