### PR TITLE
fix: Allow re-adding forms to a nested form after deleting the last one from a list

### DIFF
--- a/lib/ash_phoenix/form/form.ex
+++ b/lib/ash_phoenix/form/form.ex
@@ -4664,7 +4664,9 @@ defmodule AshPhoenix.Form do
       {:ok, form_params} ->
         case Map.fetch(params, "_drop_#{key}") do
           {:ok, drop} when is_list(drop) ->
-            Map.put(params, key, Map.drop(form_params, drop))
+            params
+            |> Map.put(key, Map.drop(form_params, drop))
+            |> Map.put("_drop_#{key}", [])
 
           _ ->
             params

--- a/test/form_test.exs
+++ b/test/form_test.exs
@@ -55,6 +55,34 @@ defmodule AshPhoenix.FormTest do
                |> Map.get(:comments)
                |> Enum.count()
     end
+
+    test "allows re-adding forms after dropping the last form" do
+      assert 1 ==
+               Post
+               |> Form.for_create(:create,
+                 domain: Domain,
+                 params: %{"text" => "bar"},
+                 forms: [
+                   comments: [
+                     type: :list,
+                     resource: Comment,
+                     create_action: :create_with_unknown_error
+                   ]
+                 ]
+               )
+               |> Form.add_form([:comments], params: %{"text" => "one"})
+               |> AshPhoenix.Form.validate(%{
+                 "text" => "bar",
+                 "_drop_comments" => ["0"],
+                 "comments" => %{
+                   "0" => %{"text" => "one"}
+                 }
+               })
+               |> Form.add_form([:comments], params: %{"text" => "two"})
+               |> Map.get(:forms)
+               |> Map.get(:comments)
+               |> Enum.count()
+    end
   end
 
   describe "sort_forms/3" do


### PR DESCRIPTION
I *think* the logic is correct, to fix another issue I spotted with adding/removing forms using the new drop param method. When the last element is deleted, `[0]` stays in the drop params meaning that even after adding a new one, it will get deleted again.

Without the code change, the test fails with the count being 0, not 1.

### Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
