### PR TITLE
fix: Show correct error message when no form is configured but a relationship is present

### DIFF
--- a/lib/ash_phoenix/form/no_form_configured.ex
+++ b/lib/ash_phoenix/form/no_form_configured.ex
@@ -92,7 +92,7 @@ defmodule AshPhoenix.Form.NoFormConfigured do
           """
         end
 
-      relationship = Ash.Resource.Info.attribute(error.resource, error.field) ->
+      relationship = Ash.Resource.Info.relationship(error.resource, error.field) ->
         """
 
         There is a relationship called `#{relationship.name}` on the resource `#{inspect(error.resource)}`.


### PR DESCRIPTION
Investigating why I was getting an error message telling me there was no relationship for my form, when there clearly is - this fixes it!