### PR TITLE
fix: In AshPhoenix.Form.errors parse path before errors get

### DIFF
--- a/lib/ash_phoenix/form/form.ex
+++ b/lib/ash_phoenix/form/form.ex
@@ -2723,7 +2723,7 @@ defmodule AshPhoenix.Form do
     end
   end
 
-  def ash_errors(form, opts \\ []) do
+  defp ash_errors(form, opts) do
     form = to_form!(form)
     opts = validate_opts_with_extra_keys(opts, @errors_opts)
 

--- a/lib/ash_phoenix/form/form.ex
+++ b/lib/ash_phoenix/form/form.ex
@@ -2718,7 +2718,7 @@ defmodule AshPhoenix.Form do
       path ->
         form
         |> gather_errors(opts[:format])
-        |> Map.get(path)
+        |> Map.get(parse_path!(form, path))
         |> List.wrap()
     end
   end

--- a/test/form_test.exs
+++ b/test/form_test.exs
@@ -1024,7 +1024,7 @@ defmodule AshPhoenix.FormTest do
       assert nested_form.errors == [{:text, {"is required", []}}]
     end
 
-    test "errors with a path are propagated down to the appropirate nested form" do
+    test "errors with a path are propagated down to the appropirate nested form for list or string path" do
       author = %Author{
         email: "me@example.com"
       }
@@ -1036,11 +1036,15 @@ defmodule AshPhoenix.FormTest do
         |> Form.validate(%{"embedded_argument" => %{"value" => "you@example.com"}})
         |> form_for("action")
 
-      assert AshPhoenix.Form.errors(form, for_path: [:embedded_argument]) == [
+      assert Form.errors(form, for_path: [:embedded_argument]) == [
                value: "must match email"
              ]
 
-      assert AshPhoenix.Form.errors(form) == []
+      assert Form.errors(form, for_path: "form[embedded_argument]") == [
+               value: "must match email"
+             ]
+
+      assert Form.errors(form) == []
 
       # Check that errors will appear on a nested form using the Phoenix Core Components inputs_for
       # https://github.com/phoenixframework/phoenix_live_view/blob/main/lib/phoenix_component.ex#L2410


### PR DESCRIPTION
#229 
Hope this is the right approach.
I expanded one test covering this fix, not sure if that counts for the check.
Question about `ash_errors`, should the path for it also be parsed? 
Also, I don't see a difference between `errors` and `ash_errors` other then `errors` does transform and format.
Should I add `@doc` and `@spec` for `ash_errors`?

### Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
