### PR TITLE
docs: fix union forms examples by adding missing public attributes

### DIFF
--- a/documentation/topics/union-forms.md
+++ b/documentation/topics/union-forms.md
@@ -9,7 +9,7 @@ defmodule NormalContent do
   use Ash.Resource, data_layer: :embedded
 
   attributes do
-    attribute :body, :string, allow_nil?: false
+    attribute :body, :string, allow_nil?: false, public?: true
   end
 
   actions do
@@ -21,7 +21,7 @@ defmodule SpecialContent do
   use Ash.Resource, data_layer: :embedded
 
   attributes do
-    attribute :text, :string, allow_nil?: false
+    attribute :text, :string, allow_nil?: false, public?: true
   end
 
   actions do


### PR DESCRIPTION
The examples in the union forms documentation were failing to update values because the embedded resource attributes weren't properly marked as public (`public? true`). This fix ensures the documented examples work correctly when copying and pasting.  Without this change, users would encounter silent failures when following the examples as the form attributes would be inaccessible for updates.

In order to reproduce the problem I've created a repo https://github.com/minibikini/ash_phoenix_union_form_example which now has a working example of a union form in Ash, perhaps someone will find it useful.