### PR TITLE
fix: unhandled error in form submission warning

### DIFF
--- a/lib/ash_phoenix/form_data/helpers.ex
+++ b/lib/ash_phoenix/form_data/helpers.ex
@@ -52,7 +52,7 @@ defmodule AshPhoenix.FormData.Helpers do
 
   @doc false
   def transform_errors(form, errors, path_filter \\ nil, form_keys \\ []) do
-    errors = Ash.Error.to_error_class(errors).errors
+    errors = if errors == [], do: [], else: Ash.Error.to_error_class(errors).errors
 
     additional_path_filters =
       form_keys


### PR DESCRIPTION
Since upgrading to ash_phoenix v2.1.21 I started seeing warnings like this on form validation:

[warning] Unhandled error in form submission for Rts.Bookings.Location.create

This error was unhandled because Ash.Error.Unknown.UnknownError does not implement the `AshPhoenix.FormData.Error` protocol.

** (Ash.Error.Unknown.UnknownError) nil

At first I thought I had just broken my code in some way. 
But I since traced it to this commit: [64c578c](https://github.com/ash-project/ash_phoenix/commit/64c578cd017103f518a51933bc89680b5515b290)

Calling Ash.Error.to_error_class([]) with empty list (i.e. no errors) returns an unknown error.
Not sure if this is how it should be fixed, but it does stop the warning from being issued. Cheers.