### PR TITLE
Test that general errors are returned even when no field is specified

### DIFF
--- a/test/form_test.exs
+++ b/test/form_test.exs
@@ -494,6 +494,17 @@ defmodule AshPhoenix.FormTest do
     refute form.valid?
   end
 
+  test "validation errors returned from after action" do
+    form = Form.for_create(Post, :create_with_failing_after_action, domain: Domain)
+    form = AshPhoenix.Form.validate(form, %{"text" => "text"})
+
+    assert form.valid?
+
+    {:error, form} = Form.submit(form, params: %{"text" => "text2"})
+
+    assert ["Action failed"] = AshPhoenix.Form.errors(form)
+  end
+
   test "blank form values unset - helps support dead view forms" do
     form =
       Form.for_create(PostWithDefault, :create,

--- a/test/support/resources/post.ex
+++ b/test/support/resources/post.ex
@@ -47,6 +47,12 @@ defmodule AshPhoenix.Test.Post do
       change before_action(fn changeset, _ -> Ash.Changeset.add_error(changeset, "nope") end)
     end
 
+    create :create_with_failing_after_action do
+      change after_action(fn _changeset, _session, _ctx ->
+               {:error, "Action failed"}
+             end)
+    end
+
     create :create do
       primary?(true)
 


### PR DESCRIPTION
As discussed in Ash Discord, test that expects errors to get returned even though they have no field specified

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
