### PR TITLE
fix typo for nested_form documentation

### DIFF
--- a/documentation/topics/nested-forms.md
+++ b/documentation/topics/nested-forms.md
@@ -191,7 +191,7 @@ be *removed* from the list. For example, given the following:
       <input
         type="checkbox"
         name={"#{@form.name}[_drop_locations][]"}
-        value={location_form.index}
+        value={location.index}
         class="hidden"
       />
 


### PR DESCRIPTION

a typo "_form" is
```
value={location_form.index}
```
fixed with
```
value={location.index}
```