### PR TITLE
improvement: Add subdomain live_view hook

### DIFF
--- a/lib/ash_phoenix/helpers.ex
+++ b/lib/ash_phoenix/helpers.ex
@@ -1,0 +1,33 @@
+defmodule AshPhoenix.Helpers do
+  def get_subdomain(%Plug.Conn{host: host}, endpoint) when is_atom(endpoint) do
+    get_subdomain(host, endpoint)
+  end
+
+  def get_subdomain(%Phoenix.Socket{endpoint: endpoint}, url) when is_binary(url) do
+    url
+    |> URI.parse()
+    |> Map.get(:host)
+    |> get_subdomain(endpoint)
+  end
+
+  def get_subdomain(host, endpoint) when is_atom(endpoint) do
+    root_host = endpoint.config(:url)[:host]
+
+    if host in [root_host, "localhost", "127.0.0.1", "0.0.0.0"] do
+      nil
+    else
+      host
+      |> String.trim_leading("www.")
+      |> String.replace(~r/.?#{root_host}/, "")
+      |> case do
+        "" ->
+          nil
+
+        subdomain ->
+          subdomain
+      end
+    end
+  end
+
+  def get_subdomain(_, _), do: nil
+end

--- a/lib/ash_phoenix/live_view/subdomain_hook.ex
+++ b/lib/ash_phoenix/live_view/subdomain_hook.ex
@@ -1,0 +1,98 @@
+defmodule AshPhoenix.LiveView.SubdomainHook do
+  @hook_options [
+    assign: [
+      type: :atom,
+      doc: "The key to use when assigning the current tenant",
+      default: :current_tenant
+    ],
+    handle_subdomain: [
+      type: :mfa,
+      doc:
+        "An mfa to call with the socket and a subdomain value. Can be used to do something like fetch the current user given the tenant.
+        Must return either `{:cont, socket}`, `{:cont, socket, opts} or `{:halt, socket}`."
+    ]
+  ]
+
+  @moduledoc """
+  This is a basic hook that loads the current tenant assign from a given
+  value set on subdomain.
+
+  Options:
+
+  #{Spark.Options.docs(@hook_options)}
+
+  To use the hook, you can do one of the following:
+
+  ```elixir
+  live_session :foo, on_mount: [
+    AshPhoenix.LiveView.SubdomainHook,
+  ]
+  ```
+  This will assign the tenant's subdomain value to `:current_tenant` key by default.
+
+  If you want to specify the assign key
+
+  ```elixir
+  live_session :foo, on_mount: [
+    {AshPhoenix.LiveView.SubdomainHook, [assign: :different_assign_key}]
+  ]
+  ```
+
+  You can also provide `handle_subdomain` module, function, arguments tuple
+  that will be run after the tenant is assigned.
+
+  ```elixir
+  live_session :foo, on_mount: [
+    {AshPhoenix.LiveView.SubdomainHook, [handle_subdomain: {FooApp.SubdomainHandler, :handle_subdomain, [:bar]}]
+  ]
+  ```
+
+  This can be any module, function, and list of arguments as it uses Elixir's [apply/3](https://hexdocs.pm/elixir/1.18.3/Kernel.html#apply/3).
+
+  The socket and tenant will be the first two arguments.
+
+  The function return must match Phoenix LiveView's [on_mount/1](https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.html#on_mount/1)
+
+  ```elixir
+  defmodule FooApp.SubdomainHandler do
+    def handle_subdomain(socket, tenant, :bar) do
+      # your logic here
+      {:cont, socket}
+    end
+  end
+  ```
+  """
+
+  import Phoenix.LiveView
+  import Phoenix.Component, only: [assign: 3]
+
+  def on_mount(opts, _params, _session, socket) when is_list(opts) do
+    opts = Spark.Options.validate!(opts, @hook_options)
+
+    socket
+    |> assign_tenant(opts)
+    |> call_handle_subdomain(opts)
+  end
+
+  def on_mount(_action, params, session, socket) do
+    on_mount([], params, session, socket)
+  end
+
+  defp assign_tenant(socket, opts) do
+    attach_hook(socket, :set_tenant, :handle_params, fn
+      _params, url, socket ->
+        subdomain = AshPhoenix.Helpers.get_subdomain(socket, url)
+        {:cont, assign(socket, opts[:assign], subdomain)}
+    end)
+  end
+
+  defp call_handle_subdomain(socket, opts) do
+    case opts[:handle_subdomain] do
+      {m, f, a} ->
+        apply(m, f, [socket, socket.assigns[opts[:assign]] | a])
+
+      _ ->
+        {:cont, socket}
+    end
+  end
+end

--- a/lib/ash_phoenix/plug/subdomain_plug.ex
+++ b/lib/ash_phoenix/plug/subdomain_plug.ex
@@ -55,14 +55,13 @@ defmodule AshPhoenix.SubdomainPlug do
         {:noreply, socket}
       end
   """
-  alias Plug.Conn
-
   @doc false
   def init(opts), do: Spark.Options.validate!(opts, @plug_options)
 
   @doc false
   def call(conn, opts) do
-    subdomain = get_subdomain(conn, opts)
+    subdomain =
+      AshPhoenix.Helpers.get_subdomain(conn, opts[:endpoint])
 
     conn
     |> Plug.Conn.assign(opts[:assign], subdomain)
@@ -71,10 +70,7 @@ defmodule AshPhoenix.SubdomainPlug do
 
   if Code.ensure_loaded?(Phoenix.LiveView) do
     def live_tenant(socket, url) do
-      url
-      |> URI.parse()
-      |> Map.get(:host)
-      |> do_get_subdomain(socket.endpoint.config(:url)[:host])
+      AshPhoenix.Helpers.get_subdomain(socket, url)
     end
   end
 
@@ -85,31 +81,6 @@ defmodule AshPhoenix.SubdomainPlug do
 
       _ ->
         conn
-    end
-  end
-
-  defp get_subdomain(
-         %Conn{host: host},
-         opts
-       ) do
-    root_host = opts[:endpoint].config(:url)[:host]
-    do_get_subdomain(host, root_host)
-  end
-
-  defp do_get_subdomain(host, root_host) do
-    if host in [root_host, "localhost", "127.0.0.1", "0.0.0.0"] do
-      nil
-    else
-      host
-      |> String.trim_leading("www.")
-      |> String.replace(~r/.?#{root_host}/, "")
-      |> case do
-        "" ->
-          nil
-
-        subdomain ->
-          subdomain
-      end
     end
   end
 end

--- a/test/helpers_test.exs
+++ b/test/helpers_test.exs
@@ -1,0 +1,76 @@
+defmodule AshPhoenix.HelpersTest do
+  use ExUnit.Case
+
+  defmodule TestEndpoint do
+    @config [
+      url: [host: "example.com"]
+    ]
+
+    def config(key, default \\ nil) do
+      Access.get(@config, key, default)
+    end
+  end
+
+  describe "get_subdomain/2" do
+    test "when non-local host contains subdomain and endpoint returns subdomain" do
+      tenant = "tenant"
+      host = "#{tenant}.example.com"
+      subdomain = AshPhoenix.Helpers.get_subdomain(host, TestEndpoint)
+
+      assert subdomain == tenant
+    end
+
+    test "when url host = endpoint host returns nil" do
+      host = "example.com"
+      subdomain = AshPhoenix.Helpers.get_subdomain(host, TestEndpoint)
+
+      assert is_nil(subdomain)
+    end
+
+    test "with url host is localhost returns nil" do
+      host = "localhost"
+      subdomain = AshPhoenix.Helpers.get_subdomain(host, TestEndpoint)
+
+      assert is_nil(subdomain)
+    end
+
+    test "when url host is 127.0.0.1 returns nil" do
+      host = "127.0.0.1"
+      subdomain = AshPhoenix.Helpers.get_subdomain(host, TestEndpoint)
+
+      assert is_nil(subdomain)
+    end
+
+    test "when url host is 0.0.0.0 returns nil" do
+      host = "0.0.0.0"
+      subdomain = AshPhoenix.Helpers.get_subdomain(host, TestEndpoint)
+
+      assert is_nil(subdomain)
+    end
+
+    test "when url host contains subdomain returns subdomain" do
+      tenant = "tenant"
+      host = "#{tenant}.example.com"
+      subdomain = AshPhoenix.Helpers.get_subdomain(host, TestEndpoint)
+
+      assert subdomain == tenant
+    end
+
+    test "when Plug.Conn host contains subdomain returns subdomain" do
+      tenant = "tenant"
+      conn = %Plug.Conn{host: "#{tenant}.example.com"}
+      subdomain = AshPhoenix.Helpers.get_subdomain(conn, TestEndpoint)
+
+      assert subdomain == tenant
+    end
+
+    test "for Phoenix.Socket returns subdomain" do
+      tenant = "tenant"
+      socket = %Phoenix.Socket{endpoint: TestEndpoint}
+      url = "https://#{tenant}.example.com"
+      subdomain = AshPhoenix.Helpers.get_subdomain(socket, url)
+
+      assert subdomain == tenant
+    end
+  end
+end


### PR DESCRIPTION
### Contributor checklist

- [ ] Bug fixes include regression tests
- [x] Features include unit/acceptance tests

- Add `AshPhoenix.LiveView.SubdomainHook` to make it easier to assign the `current_tenant` from the subdomain like `AshPhoenix.SubdomainPlug`
- Create `AshPhoenix.Helpers.get_subdomain/2` to consolidate the logic for both `SubdomainPlug` and `SubdomainHook`
- Add tests for `AshPhoenix.Helpers.get_subdomain/2`

### Examples included in the docs

To use the hook, you can do one of the following:

  ```elixir
  live_session :foo, on_mount: [
    AshPhoenix.LiveView.SubdomainHook,
  ]
  ```
  This will assign the tenant's subdomain value to `:current_tenant` key by default.

  If you want to specify the assign key

  ```elixir
  live_session :foo, on_mount: [
    {AshPhoenix.LiveView.SubdomainHook, [assign: :different_assign_key}]
  ]
  ```

  You can also provide `handle_subdomain` module, function, arguments tuple that will be run after the tenant is assigned.

  ```elixir
  live_session :foo, on_mount: [
    {AshPhoenix.LiveView.SubdomainHook, [handle_subdomain: {FooApp.SubdomainHandler, :handle_subdomain, [:bar]}]
  ]
  ```

  This can be any module, function, and list of arguments as it uses Elixir's [apply/3](https://hexdocs.pm/elixir/1.18.3/Kernel.html#apply/3).

  The socket and tenant will be the first two arguments.

  The function return must match Phoenix LiveView's [on_mount/1](https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.html#on_mount/1)

  ```elixir
  defmodule FooApp.SubdomainHandler do
    def handle_subdomain(socket, tenant, :bar) do
      # your logic here
      {:cont, socket}
    end
  end
  ```
