### PR TITLE
improvement: Add AshPhoenix.Scope to store ash context in assigns

### DIFF
--- a/lib/ash_phoenix/scope.ex
+++ b/lib/ash_phoenix/scope.ex
@@ -1,0 +1,406 @@
+defmodule AshPhoenix.Scope do
+  @moduledoc """
+  Manages scope information for Phoenix applications using Ash Framework.
+
+  This module provides utilities for working with scope data in Phoenix applications,
+  allowing you to store and retrieve information like the current actor, tenant,
+  context, and tracer in the `assigns.scope` of a `Plug.Conn` or `Phoenix.LiveView.Socket`.
+
+  ## Key Features
+
+  * Store and retrieve actor, tenant, context, and tracer information
+  * Easily update scope values
+  * Convert scope to Ash options for use with actions
+  * Works with both `Plug.Conn` and `Phoenix.LiveView.Socket`
+
+  ## Usage Examples
+
+  ```elixir
+  # Set the actor in a conn
+  conn = AshPhoenix.Scope.set_actor(conn, current_user)
+
+  # Get the actor from a socket
+  {:ok, actor} = AshPhoenix.Scope.get_actor(socket)
+
+  # Update the context
+  socket = AshPhoenix.Scope.update_context(socket, fn context ->
+    Map.put(context, :locale, "en-US")
+  end)
+
+  # Convert scope to options for an Ash action
+  opts = AshPhoenix.Scope.to_opts(conn)
+  MyApp.Post.create!(post_params, opts)
+  ```
+
+  You can use your own module name by importing `AshPhoenix.Scope`.  This is useful
+  when you want to have convenience functions for setting or getting your own fields in the scope.
+
+  These aren't necessary, but can be useful.  You can always access you're own fields with `get_scope/2`
+
+  ```elixir
+  defmodule MyApp.Scope do
+    import AshPhoenix.Scope
+
+    def set_foo(conn_or_socket, value) do
+      set_scope(conn_or_socket, :foo, value)
+    end
+
+    def get_foo(conn_or_socket) do
+      get_scope(conn_or_socket, :foo)
+    end
+
+    def get_foo!(conn_or_socket) do
+      get_scope!(conn_or_socket, :foo)
+    end
+  end
+  ```
+
+  ```elixir
+  conn_or_socket = MyApp.Scope.set_foo(conn_or_socket, :bar)
+
+  MyApp.Scope.get_foo(conn_or_socket) # {:ok, :bar}
+  MyApp.Scope.get_foo!(conn_or_socket) # :bar
+  ```
+  """
+
+  @schema [
+    actor: [
+      type: :any,
+      doc: """
+      If an actor is provided, it will be used with the authorizers of a resource to authorize access"
+      """
+    ],
+    tenant: [
+      type: :any,
+      doc: """
+      If an tenant is provided, it will be used with the authorizers of a resource to authorize access"
+      """
+    ],
+    tracer: [
+      type: {:behaviour, Ash.Tracer},
+      doc: """
+      A tracer that implements the `Ash.Tracer` behaviour. See that module for more.
+      """
+    ],
+    context: [
+      type: :map,
+      doc: """
+      A context to set for actions
+      """
+    ],
+    *: [
+      type: :any,
+      doc: """
+      Any other fields to store in the scope
+      """
+    ]
+  ]
+
+  @doc """
+  Gets the actor from the assigns.scope for `Plug.Conn` or `Phoenix.LiveView.Socket`
+  """
+  def get_actor(conn_or_socket_or_assigns) do
+    get_scope(conn_or_socket_or_assigns, :actor)
+  end
+
+  @doc """
+  Gets the actor from the assigns.scope for `Plug.Conn` or `Phoenix.LiveView.Socket` or raises
+  """
+  def get_actor!(conn_or_socket_or_assigns) do
+    get_scope!(conn_or_socket_or_assigns, :actor)
+  end
+
+  @doc """
+  Gets the tenant from the assigns.scope for `Plug.Conn` or `Phoenix.LiveView.Socket`
+  """
+  def get_tenant(conn_or_socket_or_assigns) do
+    get_scope(conn_or_socket_or_assigns, :tenant)
+  end
+
+  @doc """
+  Gets the tenant from the assigns.scope for `Plug.Conn` or `Phoenix.LiveView.Socket` or raises
+  """
+  def get_tenant!(conn_or_socket_or_assigns) do
+    get_scope!(conn_or_socket_or_assigns, :tenant)
+  end
+
+  @doc """
+  Gets the context from the assigns.scope for `Plug.Conn` or `Phoenix.LiveView.Socket`
+  """
+  def get_context(conn_or_socket_or_assigns) do
+    get_scope(conn_or_socket_or_assigns, :context)
+  end
+
+  @doc """
+  Gets the context from the assigns.scope for `Plug.Conn` or `Phoenix.LiveView.Socket` or raises
+  """
+  def get_context!(conn_or_socket_or_assigns) do
+    get_scope!(conn_or_socket_or_assigns, :context)
+  end
+
+  @doc """
+  Gets the tracer from the assigns.scope for `Plug.Conn` or `Phoenix.LiveView.Socket`
+  """
+  def get_tracer(conn_or_socket_or_assigns) do
+    get_scope(conn_or_socket_or_assigns, :tracer)
+  end
+
+  @doc """
+  Gets the tracer from the assigns.scope for `Plug.Conn` or `Phoenix.LiveView.Socket` or raises
+  """
+  def get_tracer!(conn_or_socket_or_assigns) do
+    get_scope!(conn_or_socket_or_assigns, :tracer)
+  end
+
+  @doc """
+  Gets the scope or scope value by key from the assigns.scope for `Plug.Conn` or `Phoenix.LiveView.Socket`
+
+  ## Examples
+
+      iex> conn_or_socket = %{assigns: %{scope: %{actor: %{id: 1}, foo: :bar}}}
+      iex> AshPhoenix.Scope.get_scope(conn_or_socket)
+      {:ok, %{actor: %{id: 1}, foo: :bar}}
+
+      iex> conn_or_socket = %{assigns: %{scope: %{actor: %{id: 1}, foo: :bar}}}
+      iex> AshPhoenix.Scope.get_scope(conn_or_socket, :actor)
+      {:ok, %{id: 1}}
+
+      iex> conn_or_socket = %{assigns: %{scope: %{actor: %{id: 1}, foo: :bar}}}
+      iex> AshPhoenix.Scope.get_scope(conn_or_socket, :missing)
+      {:ok, nil}
+
+      iex> conn_or_socket = %{assigns: %{}}
+      iex> AshPhoenix.Scope.get_scope(conn_or_socket)
+      {:ok, nil}
+  """
+  def get_scope(conn_or_socket_or_assigns, key \\ nil) do
+    scope =
+      case conn_or_socket_or_assigns do
+        %{assigns: assigns} ->
+          get_scope!(assigns, key)
+
+        %{scope: scope} ->
+          if key, do: Map.get(scope, key), else: scope
+
+        _ ->
+          nil
+      end
+
+    {:ok, scope}
+  end
+
+  @doc """
+  Gets the scope or scope value by key from the assigns.scope for `Plug.Conn` or `Phoenix.LiveView.Socket` or raises
+
+  ## Examples
+
+      iex> conn_or_socket = %{assigns: %{scope: %{actor: %{id: 1}, foo: :bar}}}
+      iex> AshPhoenix.Scope.get_scope!(conn_or_socket)
+      %{actor: %{id: 1}, foo: :bar}
+
+      iex> conn_or_socket = %{assigns: %{scope: %{actor: %{id: 1}, foo: :bar}}}
+      iex> AshPhoenix.Scope.get_scope!(conn_or_socket, :actor)
+      %{id: 1}
+  """
+  def get_scope!(conn_or_socket_or_assigns, key \\ nil) do
+    {:ok, scope} = get_scope(conn_or_socket_or_assigns, key)
+    scope
+  end
+
+  @doc """
+  Sets the actor in the assigns.scope for `Plug.Conn` or `Phoenix.LiveView.Socket`
+
+  ## Examples
+
+      iex> conn_or_socket = %{assigns: %{}}
+      iex> conn_or_socket = AshPhoenix.Scope.set_actor(conn_or_socket, %{id: 1})
+      iex> conn_or_socket.assigns.scope
+      %{actor: %{id: 1}}
+  """
+  def set_actor(conn_or_socket, actor) do
+    set_scope(conn_or_socket, actor: actor)
+  end
+
+  @doc """
+  Sets the tenant in the assigns.scope for `Plug.Conn` or `Phoenix.LiveView.Socket`
+
+  ## Examples
+
+      iex> conn_or_socket = %{assigns: %{}}
+      iex> conn_or_socket = AshPhoenix.Scope.set_tenant(conn_or_socket, "tenant-1")
+      iex> conn_or_socket.assigns.scope
+      %{tenant: "tenant-1"}
+  """
+  def set_tenant(conn_or_socket, tenant) do
+    set_scope(conn_or_socket, tenant: tenant)
+  end
+
+  @doc """
+  Sets the tracer in the assigns.scope for `Plug.Conn` or `Phoenix.LiveView.Socket`
+
+  ## Examples
+
+      iex> conn_or_socket = %{assigns: %{}}
+      iex> conn_or_socket = AshPhoenix.Scope.set_tracer(conn_or_socket, MyTracer)
+      iex> conn_or_socket.assigns.scope
+      %{tracer: MyTracer}
+  """
+  def set_tracer(conn_or_socket, tracer) do
+    set_scope(conn_or_socket, tracer: tracer)
+  end
+
+  @doc """
+  Sets the context in the assigns.scope for `Plug.Conn` or `Phoenix.LiveView.Socket`
+
+  ## Examples
+
+      iex> conn_or_socket = %{assigns: %{}}
+      iex> conn_or_socket = AshPhoenix.Scope.set_context(conn_or_socket, %{user_id: 1})
+      iex> conn_or_socket.assigns.scope
+      %{context: %{user_id: 1}}
+  """
+  def set_context(conn_or_socket, context) do
+    set_scope(conn_or_socket, context: context)
+  end
+
+  @doc """
+  Adds keyword list items to the assigns.scope for `Plug.Conn` or `Phoenix.LiveView.Socket`
+
+  ## Options
+  #{Spark.Options.docs(@schema)}
+
+  ## Examples
+
+      iex> conn_or_socket = %{assigns: %{}}
+      iex> conn_or_socket = AshPhoenix.Scope.set_scope(conn_or_socket, actor: %{id: 1}, foo: :bar)
+      iex> conn_or_socket.assigns.scope
+      %{actor: %{id: 1}, foo: :bar}
+
+      iex> conn_or_socket = %{assigns: %{scope: %{actor: %{id: 1}}}}
+      iex> conn_or_socket = AshPhoenix.Scope.set_scope(conn_or_socket, tenant: "tenant-1")
+      iex> conn_or_socket.assigns.scope
+      %{actor: %{id: 1}, tenant: "tenant-1"}
+  """
+  def set_scope(conn_or_socket, opts) do
+    scope =
+      case get_scope(conn_or_socket) do
+        {:ok, nil} ->
+          new(opts)
+
+        {:ok, existing_scope} when is_map(existing_scope) ->
+          existing_scope
+          |> Map.to_list()
+          |> Keyword.merge(opts)
+          |> new()
+      end
+
+    # For simple maps in doctests
+    Map.update(conn_or_socket, :assigns, %{scope: scope}, fn assigns ->
+      Map.put(assigns, :scope, scope)
+    end)
+  end
+
+  @doc """
+  Updates the actor in the assigns.scope for `Plug.Conn` or `Phoenix.LiveView.Socket`
+
+  ## Examples
+
+      iex> conn_or_socket = %{assigns: %{scope: %{actor: %{id: 1, name: "old"}}}}
+      iex> conn_or_socket = AshPhoenix.Scope.update_actor(conn_or_socket, fn actor -> %{actor | name: "new"} end)
+      iex> conn_or_socket.assigns.scope.actor
+      %{id: 1, name: "new"}
+  """
+  def update_actor(conn_or_socket, callback) do
+    update_scope(conn_or_socket, :actor, callback)
+  end
+
+  @doc """
+  Updates the tenant in the assigns.scope for `Plug.Conn` or `Phoenix.LiveView.Socket`
+
+  ## Examples
+
+      iex> conn_or_socket = %{assigns: %{scope: %{tenant: "old-tenant"}}}
+      iex> conn_or_socket = AshPhoenix.Scope.update_tenant(conn_or_socket, fn _tenant -> "new-tenant" end)
+      iex> conn_or_socket.assigns.scope.tenant
+      "new-tenant"
+  """
+  def update_tenant(conn_or_socket, callback) do
+    update_scope(conn_or_socket, :tenant, callback)
+  end
+
+  @doc """
+  Updates the context in the assigns.scope for `Plug.Conn` or `Phoenix.LiveView.Socket`
+
+  ## Examples
+
+      iex> conn_or_socket = %{assigns: %{scope: %{context: %{user_id: 1}}}}
+      iex> conn_or_socket = AshPhoenix.Scope.update_context(conn_or_socket, fn context -> Map.put(context, :role, :admin) end)
+      iex> conn_or_socket.assigns.scope.context
+      %{user_id: 1, role: :admin}
+  """
+  def update_context(conn_or_socket, callback) do
+    update_scope(conn_or_socket, :context, callback)
+  end
+
+  @doc """
+  Updates the scope by key in the assigns.scope for `Plug.Conn` or `Phoenix.LiveView.Socket`
+
+  ## Examples
+
+      iex> conn_or_socket = %{assigns: %{scope: %{foo: :bar}}}
+      iex> conn_or_socket = AshPhoenix.Scope.update_scope(conn_or_socket, :foo, fn _foo -> :baz end)
+      iex> conn_or_socket.assigns.scope.foo
+      :baz
+
+      iex> conn_or_socket = %{assigns: %{scope: %{}}}
+      iex> conn_or_socket = AshPhoenix.Scope.update_scope(conn_or_socket, :missing, fn val -> val end)
+      iex> conn_or_socket.assigns.scope
+      %{}
+  """
+  def update_scope(conn_or_socket, key, callback) do
+    case get_scope(conn_or_socket, key) do
+      {:ok, nil} ->
+        conn_or_socket
+
+      {:ok, value} ->
+        set_scope(conn_or_socket, [{key, callback.(value)}])
+    end
+  end
+
+  @doc """
+  Converts the scope to a keyword list of options to pass to an action
+
+  ## Examples
+
+      iex> conn_or_socket = %{assigns: %{scope: %{actor: %{id: 1}, tenant: "tenant-1"}}}  # No context key
+      iex> opts = AshPhoenix.Scope.to_opts(conn_or_socket)
+      iex> Keyword.get(opts, :actor) == %{id: 1} and Keyword.get(opts, :tenant) == "tenant-1"
+      true
+
+      iex> conn_or_socket = %{assigns: %{scope: %{actor: %{id: 1}, tenant: "tenant-1"}}}  # No context key
+      iex> opts = AshPhoenix.Scope.to_opts(conn_or_socket, actor: %{id: 2})
+      iex> Keyword.get(opts, :actor) == %{id: 2} and Keyword.get(opts, :tenant) == "tenant-1"
+      true
+
+      iex> conn_or_socket = %{assigns: %{}}
+      iex> AshPhoenix.Scope.to_opts(conn_or_socket)
+      []
+  """
+  def to_opts(conn_or_socket_or_assigns, opts \\ []) do
+    case get_scope(conn_or_socket_or_assigns) do
+      {:ok, scope} when is_map(scope) ->
+        scope
+        |> Ash.Context.to_opts()
+        |> Keyword.merge(opts)
+
+      _ ->
+        []
+    end
+  end
+
+  @doc false
+  defp new(opts) do
+    opts = Spark.Options.validate!(opts, @schema)
+    Map.new(opts)
+  end
+end

--- a/test/scope_test.exs
+++ b/test/scope_test.exs
@@ -1,0 +1,326 @@
+defmodule AshPhoenix.ScopeTest do
+  use ExUnit.Case, async: true
+  doctest AshPhoenix.Scope
+
+  alias AshPhoenix.Scope
+
+  defmodule User do
+    defstruct [:id, :name]
+  end
+
+  defmodule Tenant do
+    defstruct [:id, :name]
+  end
+
+  describe "get_scope/1-2" do
+    test "gets entire scope from map" do
+      user = %User{id: 1, name: "John Doe"}
+      tenant = %Tenant{id: "tenant-1", name: "Acme Inc"}
+      context = %{locale: "en"}
+
+      scope = %{actor: user, tenant: tenant, context: context}
+      conn_or_socket = %{assigns: %{scope: scope}}
+
+      assert {:ok, ^scope} = Scope.get_scope(conn_or_socket)
+    end
+
+    test "gets scope value by key" do
+      user = %User{id: 1, name: "John Doe"}
+      tenant = %Tenant{id: "tenant-1", name: "Acme Inc"}
+      context = %{locale: "en"}
+
+      scope = %{actor: user, tenant: tenant, context: context}
+      conn_or_socket = %{assigns: %{scope: scope}}
+
+      assert {:ok, ^user} = Scope.get_scope(conn_or_socket, :actor)
+      assert {:ok, ^tenant} = Scope.get_scope(conn_or_socket, :tenant)
+      assert {:ok, ^context} = Scope.get_scope(conn_or_socket, :context)
+    end
+
+    test "returns nil for missing key" do
+      user = %User{id: 1, name: "John Doe"}
+      scope = %{actor: user}
+      conn_or_socket = %{assigns: %{scope: scope}}
+
+      assert {:ok, nil} = Scope.get_scope(conn_or_socket, :missing)
+    end
+
+    test "returns nil for missing scope" do
+      conn_or_socket = %{assigns: %{}}
+
+      assert {:ok, nil} = Scope.get_scope(conn_or_socket)
+    end
+  end
+
+  describe "get_scope!/1-2" do
+    test "gets entire scope from map" do
+      user = %User{id: 1, name: "John Doe"}
+      tenant = %Tenant{id: "tenant-1", name: "Acme Inc"}
+      context = %{locale: "en"}
+
+      scope = %{actor: user, tenant: tenant, context: context}
+      conn_or_socket = %{assigns: %{scope: scope}}
+
+      assert Scope.get_scope!(conn_or_socket) == scope
+    end
+
+    test "gets scope value by key" do
+      user = %User{id: 1, name: "John Doe"}
+      tenant = %Tenant{id: "tenant-1", name: "Acme Inc"}
+      context = %{locale: "en"}
+
+      scope = %{actor: user, tenant: tenant, context: context}
+      conn_or_socket = %{assigns: %{scope: scope}}
+
+      assert Scope.get_scope!(conn_or_socket, :actor) == user
+      assert Scope.get_scope!(conn_or_socket, :tenant) == tenant
+      assert Scope.get_scope!(conn_or_socket, :context) == context
+    end
+  end
+
+  describe "get_actor/1 and get_actor!/1" do
+    test "gets actor from scope" do
+      user = %User{id: 1, name: "John Doe"}
+      scope = %{actor: user}
+      conn_or_socket = %{assigns: %{scope: scope}}
+
+      assert {:ok, ^user} = Scope.get_actor(conn_or_socket)
+      assert Scope.get_actor!(conn_or_socket) == user
+    end
+
+    test "returns nil for missing actor" do
+      conn_or_socket = %{assigns: %{scope: %{}}}
+
+      assert {:ok, nil} = Scope.get_actor(conn_or_socket)
+    end
+  end
+
+  describe "get_tenant/1 and get_tenant!/1" do
+    test "gets tenant from scope" do
+      tenant = %Tenant{id: "tenant-1", name: "Acme Inc"}
+      scope = %{tenant: tenant}
+      conn_or_socket = %{assigns: %{scope: scope}}
+
+      assert {:ok, ^tenant} = Scope.get_tenant(conn_or_socket)
+      assert Scope.get_tenant!(conn_or_socket) == tenant
+    end
+
+    test "returns nil for missing tenant" do
+      conn_or_socket = %{assigns: %{scope: %{}}}
+
+      assert {:ok, nil} = Scope.get_tenant(conn_or_socket)
+    end
+  end
+
+  describe "get_context/1 and get_context!/1" do
+    test "gets context from scope" do
+      context = %{locale: "en"}
+      scope = %{context: context}
+      conn_or_socket = %{assigns: %{scope: scope}}
+
+      assert {:ok, ^context} = Scope.get_context(conn_or_socket)
+      assert Scope.get_context!(conn_or_socket) == context
+    end
+
+    test "returns nil for missing context" do
+      conn_or_socket = %{assigns: %{scope: %{}}}
+
+      assert {:ok, nil} = Scope.get_context(conn_or_socket)
+    end
+  end
+
+  describe "get_tracer/1 and get_tracer!/1" do
+    test "gets tracer from scope" do
+      scope = %{tracer: Ash.Tracer.Simple}
+      conn_or_socket = %{assigns: %{scope: scope}}
+
+      assert {:ok, Ash.Tracer.Simple} = Scope.get_tracer(conn_or_socket)
+      assert Scope.get_tracer!(conn_or_socket) == Ash.Tracer.Simple
+    end
+
+    test "returns nil for missing tracer" do
+      conn_or_socket = %{assigns: %{scope: %{}}}
+
+      assert {:ok, nil} = Scope.get_tracer(conn_or_socket)
+    end
+  end
+
+  describe "set_scope/2" do
+    test "sets scope with various options" do
+      user = %User{id: 1, name: "John Doe"}
+      tenant = %Tenant{id: "tenant-1", name: "Acme Inc"}
+      context = %{locale: "en"}
+
+      conn_or_socket = %{assigns: %{}}
+
+      result =
+        Scope.set_scope(conn_or_socket, actor: user, tenant: tenant, context: context, foo: :bar)
+
+      assert result.assigns.scope.actor == user
+      assert result.assigns.scope.tenant == tenant
+      assert result.assigns.scope.context == context
+      assert result.assigns.scope.foo == :bar
+    end
+
+    test "merges with existing scope" do
+      user = %User{id: 1, name: "John Doe"}
+      tenant = %Tenant{id: "tenant-1", name: "Acme Inc"}
+
+      conn_or_socket = %{assigns: %{scope: %{actor: user}}}
+
+      result = Scope.set_scope(conn_or_socket, tenant: tenant)
+
+      assert result.assigns.scope.actor == user
+      assert result.assigns.scope.tenant == tenant
+    end
+  end
+
+  describe "set_actor/2" do
+    test "sets actor in scope" do
+      user = %User{id: 1, name: "John Doe"}
+      conn_or_socket = %{assigns: %{}}
+
+      result = Scope.set_actor(conn_or_socket, user)
+
+      assert result.assigns.scope.actor == user
+    end
+  end
+
+  describe "set_tenant/2" do
+    test "sets tenant in scope" do
+      tenant = %Tenant{id: "tenant-1", name: "Acme Inc"}
+      conn_or_socket = %{assigns: %{}}
+
+      result = Scope.set_tenant(conn_or_socket, tenant)
+
+      assert result.assigns.scope.tenant == tenant
+    end
+  end
+
+  describe "set_context/2" do
+    test "sets context in scope" do
+      context = %{locale: "en"}
+      conn_or_socket = %{assigns: %{}}
+
+      result = Scope.set_context(conn_or_socket, context)
+
+      assert result.assigns.scope.context == context
+    end
+  end
+
+  describe "set_tracer/2" do
+    test "sets tracer in scope" do
+      conn_or_socket = %{assigns: %{}}
+
+      result = Scope.set_tracer(conn_or_socket, Ash.Tracer.Simple)
+
+      assert result.assigns.scope.tracer == Ash.Tracer.Simple
+    end
+  end
+
+  describe "update_scope/3" do
+    test "updates existing value in scope" do
+      user = %User{id: 1, name: "John Doe"}
+      conn_or_socket = %{assigns: %{scope: %{actor: user}}}
+
+      result =
+        Scope.update_scope(conn_or_socket, :actor, fn actor -> %{actor | name: "Jane Doe"} end)
+
+      assert result.assigns.scope.actor.name == "Jane Doe"
+      assert result.assigns.scope.actor.id == 1
+    end
+
+    test "does nothing for missing key" do
+      conn_or_socket = %{assigns: %{scope: %{}}}
+
+      result = Scope.update_scope(conn_or_socket, :missing, fn val -> val end)
+
+      assert result == conn_or_socket
+    end
+  end
+
+  describe "update_actor/2" do
+    test "updates actor in scope" do
+      user = %User{id: 1, name: "John Doe"}
+      conn_or_socket = %{assigns: %{scope: %{actor: user}}}
+
+      result = Scope.update_actor(conn_or_socket, fn actor -> %{actor | name: "Jane Doe"} end)
+
+      assert result.assigns.scope.actor.name == "Jane Doe"
+      assert result.assigns.scope.actor.id == 1
+    end
+  end
+
+  describe "update_tenant/2" do
+    test "updates tenant in scope" do
+      tenant = %Tenant{id: "tenant-1", name: "Acme Inc"}
+      conn_or_socket = %{assigns: %{scope: %{tenant: tenant}}}
+
+      result = Scope.update_tenant(conn_or_socket, fn tenant -> %{tenant | name: "New Name"} end)
+
+      assert result.assigns.scope.tenant.name == "New Name"
+      assert result.assigns.scope.tenant.id == "tenant-1"
+    end
+  end
+
+  describe "update_context/2" do
+    test "updates context in scope" do
+      context = %{locale: "en"}
+      conn_or_socket = %{assigns: %{scope: %{context: context}}}
+
+      result =
+        Scope.update_context(conn_or_socket, fn context -> Map.put(context, :theme, "dark") end)
+
+      assert result.assigns.scope.context.locale == "en"
+      assert result.assigns.scope.context.theme == "dark"
+    end
+  end
+
+  describe "to_opts/1-2" do
+    test "converts scope to keyword list with Ash.Context.to_opts" do
+      user = %User{id: 1, name: "John Doe"}
+      tenant = %Tenant{id: "tenant-1", name: "Acme Inc"}
+      context = %{locale: "en"}
+
+      conn_or_socket = %{assigns: %{scope: %{actor: user, tenant: tenant, context: context}}}
+
+      opts = Scope.to_opts(conn_or_socket)
+
+      assert Keyword.get(opts, :actor) == user
+      assert Keyword.get(opts, :tenant) == tenant
+      assert Keyword.get(opts, :context) == nil
+    end
+
+    test "merges with additional options" do
+      user = %User{id: 1, name: "John Doe"}
+      tenant = %Tenant{id: "tenant-1", name: "Acme Inc"}
+
+      conn_or_socket = %{assigns: %{scope: %{actor: user, tenant: tenant}}}
+
+      opts = Scope.to_opts(conn_or_socket, authorize?: false)
+
+      assert Keyword.get(opts, :actor) == user
+      assert Keyword.get(opts, :tenant) == tenant
+      assert Keyword.get(opts, :authorize?) == false
+    end
+
+    test "overrides scope values with provided options" do
+      user = %User{id: 1, name: "John Doe"}
+      new_user = %User{id: 2, name: "Jane Doe"}
+      tenant = %Tenant{id: "tenant-1", name: "Acme Inc"}
+
+      conn_or_socket = %{assigns: %{scope: %{actor: user, tenant: tenant}}}
+
+      opts = Scope.to_opts(conn_or_socket, actor: new_user)
+
+      assert Keyword.get(opts, :actor) == new_user
+      assert Keyword.get(opts, :tenant) == tenant
+    end
+
+    test "returns empty list for missing scope" do
+      conn_or_socket = %{assigns: %{}}
+
+      assert Scope.to_opts(conn_or_socket) == []
+    end
+  end
+end


### PR DESCRIPTION
Closes ash-project/ash#1983 

- Add `AshPhoenix.Scope` that stores `tenant`, `actor`, `tracer`, `context`, and any other fields in `Plug.Conn` or `Phoenix.LiveView.Socket` assigns. Provides convenience functions for setting and getting the ash context values.
- Allow providing any fields to include in the scope
- Allow adding additional or overriding existing opts when calling `AshPhoenix.Scope.to_opts`
- Add documentation for all functions and examples of using your own module by importing `AshPhoenix.Scope`
- Add tests for `AshPhoenix.Scope`

### Contributor checklist

- [ ] Bug fixes include regression tests
- [x] Features include unit/acceptance tests

You can use `AshPhoenix.Scope` directly or create your own module with `import AshPhoenix.Scope`.  Users can now provide any additional fields with `set_scope/2`.

The primary use for this module is to set the scope in plugs or on_mount hooks so the scope is available in your dead or live views.

```elixir
AshPhoenix.set_scope(conn_or_socket, foo: :bar)
```

For ash context scope
- `set_actor/2`, `get_actor/1`, `get_actor!/1`, `update_actor/2`
- `set_tenant/2`, `get_tenant/1`, `get_tenant!/1`, `update_tenant2`
- `set_tracer/2`, `get_tracer/1`, `get_tracer!/1`, `update_tracer/2`
- `set_context/2`, `get_context/1`, `get_context!/1`, `update_context/2`

For user-defined fields
- `set_scope/2`, `get_scope/2`, `update_scope/3`

Retrieve the whole scope map with `get_scope/1`
```elixir
# scope = %{scope: %{tenant: {id: 1}}
AshPhoenix.Scope.get_scope(conn_or_socket_or_assigns)
%{tenant: {id: 1}}
```

Retrive the values of any field with `get_scope/2`

```elixir
AshPhoenix.get_scope(conn_or_socket_or_assigns, :foo)
{:ok, :bar}

AshPhoenix.get_scope!(conn_or_socket_or_assigns, :foo)
:bar
```

Per the feedback in issue ash-project/ash#1983 from @zachdaniel , additional or override opts can be provided when calling `AshPhoenix.to_opts/1`

```elixir
# scope = %{scope: %{tenant: {id: 1}}
AshPhoenix.to_opts(conn_or_socket_or_assigns, authorize?: false)
[tenant: %{id: 1}, authorize?: false]

AshPhoenix.to_opts(conn_or_socket_or_assigns, authorize?: false, tenant: %{id: 2})
[tenant: %{id: 2}, authorize?: false]
```

You can use your module and add convenience functions if you'd like for commonly accessed scope values.

```elixir
defmodule MyApp.Scope do
    import AshPhoenix.Scope

   def set_foo(conn_or_socket, foo) do
       set_scope(conn_or_socket, :foo, foo)
   end

   def get_foo(conn_or_socket_or_assigns) do
      get_scope(conn_or_socket_or_assigns, :foo)
   end

   def get_foo!(conn_or_socket_or_assigns) do
      get_scope!(conn_or_socket_or_assigns, :foo)
   end
end
```
