### PR TITLE
feat: Add Igniter installer and set up DSL formatting

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,6 +1,12 @@
 # Used by "mix format"
+spark_locals_without_parens = [args: 1, form: 1, form: 2]
+
 [
   import_deps: [:ash, :phoenix],
   plugins: [Phoenix.LiveView.HTMLFormatter],
-  inputs: ["{mix}.exs", "{config,lib,test}/**/*.{ex,exs,heex}"]
+  inputs: ["{mix}.exs", "{config,lib,test}/**/*.{ex,exs,heex}"],
+  locals_without_parens: spark_locals_without_parens,
+  export: [
+    locals_without_parens: spark_locals_without_parens
+  ]
 ]

--- a/lib/mix/tasks/ash_phoenix.install.ex
+++ b/lib/mix/tasks/ash_phoenix.install.ex
@@ -10,7 +10,9 @@ if Code.ensure_loaded?(Igniter) do
 
     @impl Igniter.Mix.Task
     def info(_argv, _source) do
-      %Igniter.Mix.Task.Info{}
+      %Igniter.Mix.Task.Info{
+        group: :ash
+      }
     end
 
     @impl Igniter.Mix.Task

--- a/lib/mix/tasks/ash_phoenix.install.ex
+++ b/lib/mix/tasks/ash_phoenix.install.ex
@@ -1,0 +1,42 @@
+if Code.ensure_loaded?(Igniter) do
+  defmodule Mix.Tasks.AshPhoenix.Install do
+    @shortdoc "Installs AshPhoenix into a project. Should be called with `mix igniter.install ash_phoenix`"
+
+    @moduledoc """
+    #{@shortdoc}
+    """
+
+    use Igniter.Mix.Task
+
+    @impl Igniter.Mix.Task
+    def info(_argv, _source) do
+      %Igniter.Mix.Task.Info{}
+    end
+
+    @impl Igniter.Mix.Task
+    def igniter(igniter) do
+      igniter
+      |> Igniter.Project.Formatter.import_dep(:ash_phoenix)
+    end
+  end
+else
+  defmodule Mix.Tasks.AshPhoenix.Install do
+    @moduledoc "Installs AshPhoenix into a project. Should be called with `mix igniter.install ash_phoenix`"
+
+    @shortdoc @moduledoc
+
+    use Mix.Task
+
+    def run(_argv) do
+      Mix.shell().error("""
+      The task 'ash_phoenix.install' requires igniter to be run.
+
+      Please install igniter and try again.
+
+      For more information, see: https://hexdocs.pm/igniter
+      """)
+
+      exit({:shutdown, 1})
+    end
+  end
+end


### PR DESCRIPTION
Putting this in a PR because this is the first time I've ever created an Igniter installer - do I need more in the `info` callback? I copied and pasted this from the Ash Igniter installer and ripped out all the bits I didn't need.

I tested this by pointing Tunez to my local AshPhoenix checkout - I could then run `mix ash_phoenix.install`, which added `ash_phoenix` to the formatter list. Running `mix format` then removes parens from code like `form(:create_artist, args: [:artist_id])`.