### PR TITLE
Fix: Accept Phoenix.LiveView.Socket in SubdomainPlug

### DIFF
--- a/lib/ash_phoenix/helpers.ex
+++ b/lib/ash_phoenix/helpers.ex
@@ -4,7 +4,7 @@ defmodule AshPhoenix.Helpers do
     get_subdomain(host, endpoint)
   end
 
-  def get_subdomain(%{endpoint: endpoint}, url) when is_atom(endpoint) and is_binary(url) do
+  def get_subdomain(%{endpoint: endpoint}, url) when not is_nil(endpoint) and is_atom(endpoint) and is_binary(url) do
     url
     |> URI.parse()
     |> Map.get(:host)

--- a/lib/ash_phoenix/helpers.ex
+++ b/lib/ash_phoenix/helpers.ex
@@ -4,7 +4,7 @@ defmodule AshPhoenix.Helpers do
     get_subdomain(host, endpoint)
   end
 
-  def get_subdomain(%Phoenix.Socket{endpoint: endpoint}, url) when is_binary(url) do
+  def get_subdomain(%{endpoint: endpoint}, url) when is_atom(endpoint) and is_binary(url) do
     url
     |> URI.parse()
     |> Map.get(:host)

--- a/test/helpers_test.exs
+++ b/test/helpers_test.exs
@@ -72,5 +72,14 @@ defmodule AshPhoenix.HelpersTest do
 
       assert subdomain == tenant
     end
+
+    test "for Phoenix.LiveView.Socket returns subdomain" do
+      tenant = "tenant"
+      socket = %Phoenix.LiveView.Socket{endpoint: TestEndpoint}
+      url = "https://#{tenant}.example.com"
+      subdomain = AshPhoenix.Helpers.get_subdomain(socket, url)
+
+      assert subdomain == tenant
+    end
   end
 end


### PR DESCRIPTION
Allows the use of `Phoenix.LiveView.Socket` in the `get_subdomain` function in alignment with the [`SubdomainPlug` docs](https://hexdocs.pm/ash_phoenix/AshPhoenix.SubdomainPlug.html).

One other problem I ran into while following the docs was that the assign `current_tenant` was set as `nil` before `handle_params` in my LiveView was reached. The example code (again, from the `SubdomainPlug` docs) reads as follows:

```ex
def handle_params(params, uri, socket) do
  socket =
    assign_new(socket, :current_tenant, fn ->
      AshPhoenix.SubdomainPlug.live_tenant(socket, uri)
    end)
    
...
end
```

But of course, because the `current_tenant` is already set, `live_tenant` is never called. I couldn't find anywhere in the `ash_phoenix` repo where this might have been predefined, but I did see it being set in `ash_authentication_phoenix` [here](https://github.com/team-alembic/ash_authentication_phoenix/blob/06f614cbabf6b2bea911425298d6752d437bd452/lib/ash_authentication_phoenix/live_session.ex#L145).

My investigation led me to the conclusion that because `current_tenant` is used heavily in `ash_authentication_phoenix`, there might be no reason to allow the Plug option `:assign` in `SubdomainPlug`. I suspect that if I tried changing the tenant assign name to something else, my authentication wouldn't function with Ash Authentication. But I guess I haven't tried anything since I'm still setting up my new project.

### Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
