### PR TITLE
Make :params available for for_action() with test and add :params' document for all for_* actions

### DIFF
--- a/lib/ash_phoenix/form/form.ex
+++ b/lib/ash_phoenix/form/form.ex
@@ -285,6 +285,13 @@ defmodule AshPhoenix.Form do
     tenant: [
       type: :any,
       doc: "The current tenant. Passed through to the underlying action."
+    ],
+    params: [
+      type: :any,
+      default: %{},
+      doc: """
+      The initial parameters to use for the form. This is useful for setting up a form with default values.
+      """
     ]
   ]
 
@@ -6001,7 +6008,8 @@ defmodule AshPhoenix.Form do
       :transform_params,
       :prepare_params,
       :prepare_source,
-      :warn_on_unhandled_errors?
+      :warn_on_unhandled_errors?,
+      :params
     ])
   end
 end

--- a/lib/ash_phoenix/form/form.ex
+++ b/lib/ash_phoenix/form/form.ex
@@ -6009,8 +6009,7 @@ defmodule AshPhoenix.Form do
       :transform_params,
       :prepare_params,
       :prepare_source,
-      :warn_on_unhandled_errors?,
-      :params
+      :warn_on_unhandled_errors?
     ])
   end
 end

--- a/test/form_test.exs
+++ b/test/form_test.exs
@@ -25,13 +25,13 @@ defmodule AshPhoenix.FormTest do
                |> Form.submit!(params: params)
     end
 
-    test "generic actions can have forms with initial params" do
+    test "generic actions can accept initial params" do
       params = %{containing: "hello"}
 
       assert 0 =
                Post
                |> Form.for_action(:post_count, params: params)
-               |> Form.submit!(params: params)
+               |> Form.submit!(params: %{})
     end
   end
 

--- a/test/form_test.exs
+++ b/test/form_test.exs
@@ -20,7 +20,7 @@ defmodule AshPhoenix.FormTest do
 
       assert 0 =
                Post
-               |> Form.for_action(:post_count, params: params)
+               |> Form.for_action(:post_count)
                |> Form.validate(params)
                |> Form.submit!(params: params)
     end
@@ -31,7 +31,7 @@ defmodule AshPhoenix.FormTest do
       assert 0 =
                Post
                |> Form.for_action(:post_count, params: params)
-               |> Form.submit!(params: %{})
+               |> Form.submit!(params: nil)
     end
   end
 

--- a/test/form_test.exs
+++ b/test/form_test.exs
@@ -24,6 +24,15 @@ defmodule AshPhoenix.FormTest do
                |> Form.validate(params)
                |> Form.submit!(params: params)
     end
+
+    test "generic actions can have forms with initial params" do
+      params = %{containing: "hello"}
+
+      assert 0 =
+               Post
+               |> Form.for_action(:post_count, params: params)
+               |> Form.submit!(params: params)
+    end
   end
 
   describe "drop_param" do


### PR DESCRIPTION
### Contributor checklist

- [X] Bug fixes include regression tests
- [] Features include unit/acceptance tests
