### PR TITLE
Initialize :raw_params field of for_action() Form

### DIFF
--- a/lib/ash_phoenix/form/form.ex
+++ b/lib/ash_phoenix/form/form.ex
@@ -285,6 +285,13 @@ defmodule AshPhoenix.Form do
     tenant: [
       type: :any,
       doc: "The current tenant. Passed through to the underlying action."
+    ],
+    params: [
+      type: :any,
+      default: %{},
+      doc: """
+      The initial parameters to use for the form. This is useful for setting up a form with default values.
+      """
     ]
   ]
 
@@ -6001,7 +6008,8 @@ defmodule AshPhoenix.Form do
       :transform_params,
       :prepare_params,
       :prepare_source,
-      :warn_on_unhandled_errors?
+      :warn_on_unhandled_errors?,
+      :params
     ])
   end
 end

--- a/lib/ash_phoenix/form/form.ex
+++ b/lib/ash_phoenix/form/form.ex
@@ -6009,8 +6009,7 @@ defmodule AshPhoenix.Form do
       :transform_params,
       :prepare_params,
       :prepare_source,
-      :warn_on_unhandled_errors?,
-      :params
+      :warn_on_unhandled_errors?
     ])
   end
 end

--- a/lib/ash_phoenix/form/form.ex
+++ b/lib/ash_phoenix/form/form.ex
@@ -518,6 +518,7 @@ defmodule AshPhoenix.Form do
       type: :action,
       data: opts[:data],
       params: params,
+      raw_params: opts[:params] || %{},
       errors: opts[:errors],
       transform_errors: opts[:transform_errors],
       warn_on_unhandled_errors?: opts[:warn_on_unhandled_errors?],

--- a/test/form_test.exs
+++ b/test/form_test.exs
@@ -25,13 +25,13 @@ defmodule AshPhoenix.FormTest do
                |> Form.submit!(params: params)
     end
 
-    test "generic actions can have forms with initial params" do
+    test "generic actions can accept initial params" do
       params = %{containing: "hello"}
 
       assert 0 =
                Post
                |> Form.for_action(:post_count, params: params)
-               |> Form.submit!(params: params)
+               |> Form.submit!(params: %{})
     end
   end
 

--- a/test/form_test.exs
+++ b/test/form_test.exs
@@ -33,6 +33,16 @@ defmodule AshPhoenix.FormTest do
                |> Form.for_action(:post_count, params: params)
                |> Form.submit!(params: nil)
     end
+
+    test "the INITIAL generic actions Form can be update_params() in phx-change event handler" do
+      assert 0 =
+               Post
+               |> Form.for_action(:post_count)
+               |> Form.update_params(fn params ->
+                 Map.put(params, "containing", "hello")
+               end)
+               |> Form.submit!(params: nil)
+    end
   end
 
   describe "drop_param" do

--- a/test/form_test.exs
+++ b/test/form_test.exs
@@ -20,7 +20,7 @@ defmodule AshPhoenix.FormTest do
 
       assert 0 =
                Post
-               |> Form.for_action(:post_count, params: params)
+               |> Form.for_action(:post_count)
                |> Form.validate(params)
                |> Form.submit!(params: params)
     end
@@ -31,7 +31,7 @@ defmodule AshPhoenix.FormTest do
       assert 0 =
                Post
                |> Form.for_action(:post_count, params: params)
-               |> Form.submit!(params: %{})
+               |> Form.submit!(params: nil)
     end
   end
 

--- a/test/form_test.exs
+++ b/test/form_test.exs
@@ -24,6 +24,15 @@ defmodule AshPhoenix.FormTest do
                |> Form.validate(params)
                |> Form.submit!(params: params)
     end
+
+    test "generic actions can have forms with initial params" do
+      params = %{containing: "hello"}
+
+      assert 0 =
+               Post
+               |> Form.for_action(:post_count, params: params)
+               |> Form.submit!(params: params)
+    end
   end
 
   describe "drop_param" do


### PR DESCRIPTION
### Contributor checklist
- [X] Bug fixes include regression tests

AshPhoenix.Form.update_params() may fail on a AshPhoenix.Form.for_action() because of the :raw_params field was not initialized.

Error:
** (BadMapError) expected a map, got: nil