### PR TITLE
improvement: new generator tweaks

### DIFF
--- a/lib/ash_phoenix/gen/live.ex
+++ b/lib/ash_phoenix/gen/live.ex
@@ -90,7 +90,7 @@ if Code.ensure_loaded?(Igniter) do
           Igniter.add_notice(igniter, """
           Add the live routes to your browser scope in #{web_path(igniter)}/router.ex:
 
-          #{for line <- live_route_instructions(assigns), do: "    #{line}"}
+          #{for line <- live_route_instructions(assigns, opts[:phx_version]), do: "    #{line}"}
           """)
         else
           igniter
@@ -99,17 +99,17 @@ if Code.ensure_loaded?(Igniter) do
       igniter
     end
 
-    defp live_route_instructions(assigns) do
+    defp live_route_instructions(assigns, phx_version) do
       [
         ~s|live "/#{assigns[:resource_plural]}", #{assigns[:resource_alias]}Live.Index, :index\n|,
         if assigns[:create_action] do
           ~s|live "/#{assigns[:resource_plural]}/new", #{assigns[:resource_alias]}Live.Form, :new\n|
         end,
         if assigns[:update_action] do
-          ~s|live "/#{assigns[:resource_plural]}/:id/edit", #{assigns[:resource_alias]}Live.Form, :edit\n\n|
+          ~s|live "/#{assigns[:resource_plural]}/:id/edit", #{assigns[:resource_alias]}Live.Form, :edit\n|
         end,
         ~s|live "/#{assigns[:resource_plural]}/:id", #{assigns[:resource_alias]}Live.Show, :show\n|,
-        if assigns[:update_action] do
+        if assigns[:update_action] != nil and not String.starts_with?(phx_version, "1.8") do
           ~s|live "/#{assigns[:resource_plural]}/:id/show/edit", #{assigns[:resource_alias]}Live.Show, :edit|
         end
       ]

--- a/priv/templates/ash_phoenix.gen.live/new/form.ex.eex
+++ b/priv/templates/ash_phoenix.gen.live/new/form.ex.eex
@@ -46,7 +46,7 @@ defmodule <%= inspect Module.concat(@web_module, @resource_alias) %>Live.Form do
     <%= @resource_singular %> =
       case params["id"] do
         nil -> nil
-        id -> Ash.get!(<%= inspect Module.concat(Elixir, @resource) %>, id)
+        id -> Ash.get!(<%= inspect Module.concat(Elixir, @resource) %>, id<%= @actor_opt %>)
       end
 
     action = if is_nil(<%= @resource_singular %>), do: "New", else: "Edit"

--- a/priv/templates/ash_phoenix.gen.live/new/index.ex.eex
+++ b/priv/templates/ash_phoenix.gen.live/new/index.ex.eex
@@ -41,63 +41,21 @@ defmodule <%= inspect Module.concat(@web_module, @resource_alias) %>Live.Index d
         </:action>
         <% end %>
       </.table>
-    </div>
+    </Layouts.app>
     """
   end
 
   @impl true
   def mount(_params, _session, socket) do
-    <%= if @actor do %>
-      {:ok,
-        socket
-        <%= if @actor do %>
-          |> stream(:<%= @resource_plural %>, Ash.read!(<%= @resource %>, actor: socket.assigns[:<%= @actor %>]))
-        <% else %>
-          |> stream(:<%= @resource_plural %>, Ash.read!(<%= @resource %>))
-        <% end %>
-        |> assign_new(:<%= @actor %>, fn -> nil end)}
-    <% else %>
-      {:ok, stream(socket, :<%= @resource_plural %>, Ash.read!(<%= @resource %>))}
-    <% end %>
-  end
-
-  @impl true
-  def handle_params(params, _url, socket) do
-    {:noreply, apply_action(socket, socket.assigns.live_action, params)}
-  end
-
-  <%= if @update_action do %>
-    defp apply_action(socket, :edit, %{"<%= @pkey %>" => <%= @pkey %>}) do
+    {:ok,
       socket
-      |> assign(:page_title, "Edit <%= @resource_human_singular %>")
-      |> assign(:<%= @resource_singular %>, <%= @get_by_pkey %>)
-    end
-  <% end %>
-
-  <%= if @create_action do %>
-    defp apply_action(socket, :new, _params) do
-      socket
-      |> assign(:page_title, "New <%= @resource_human_singular %>")
-      <%= if @update_action do %>
-        |> assign(:<%= @resource_singular %>, nil)
+      |> assign(:page_title, "Listing <%= @resource_human_plural %>")
+      <%= if @actor do %>
+      |> stream(:<%= @resource_plural %>, Ash.read!(<%= @resource %>, actor: socket.assigns[:<%= @actor %>]))}
+      <% else %>
+      |> stream(:<%= @resource_plural %>, Ash.read!(<%= @resource %>))}
       <% end %>
-    end
-  <% end %>
-
-  defp apply_action(socket, :index, _params) do
-    socket
-    |> assign(:page_title, "Listing <%= @resource_human_plural %>")
-    <%= if @update_action || @create_action do %>
-      |> assign(:<%= @resource_singular %>, nil)
-    <% end %>
   end
-
-  <%= if @create_action || @update_action do %>
-    @impl true
-    def handle_info({<%= inspect Module.concat(@web_module, @resource_alias) %>Live.FormComponent, {:saved, <%= @resource_singular %>}}, socket) do
-      {:noreply, stream_insert(socket, :<%= @resource_plural %>, <%= @resource_singular %>)}
-    end
-  <% end %>
 
   <%= if @destroy do %>
   @impl true

--- a/priv/templates/ash_phoenix.gen.live/new/show.ex.eex
+++ b/priv/templates/ash_phoenix.gen.live/new/show.ex.eex
@@ -30,18 +30,10 @@ defmodule <%= inspect Module.concat(@web_module, @resource_alias) %>Live.Show do
   end
 
   @impl true
-  def mount(_params, _session, socket) do
-    {:ok, socket}
+  def mount(%{"<%= @pkey %>" => <%= @pkey %>}, _session, socket) do
+    {:ok,
+      socket
+      |> assign(:page_title, "Show <%= @resource_human_singular %>")
+      |> assign(:<%= @resource_singular %>, <%= @get_by_pkey %>)}
   end
-
-  @impl true
-  def handle_params(%{"<%= @pkey %>" => <%= @pkey %>}, _, socket) do
-    {:noreply,
-     socket
-     |> assign(:page_title, page_title(socket.assigns.live_action))
-     |> assign(:<%= @resource_singular %>, <%= @get_by_pkey %>)}
-  end
-
-  defp page_title(:show), do: "Show <%= @resource_human_singular %>"
-  defp page_title(:edit), do: "Edit <%= @resource_human_singular %>"
 end

--- a/test/mix/tasks/ash_phoenix.gen.live_test.exs
+++ b/test/mix/tasks/ash_phoenix.gen.live_test.exs
@@ -507,20 +507,13 @@ defmodule Mix.Tasks.AshPhoenix.Gen.LiveTest do
       end
 
       @impl true
-      def mount(_params, _session, socket) do
-      {:ok, socket}
+      def mount(%{"id" => id}, _session, socket) do
+        {:ok,
+          socket
+          |> assign(:page_title, "Show Artist")
+          |> assign(:artist, Ash.get!(AshPhoenix.Test.Artist, id, actor: socket.assigns.current_user))}
       end
 
-      @impl true
-      def handle_params(%{"id" => id}, _, socket) do
-      {:noreply,
-       socket
-       |> assign(:page_title, page_title(socket.assigns.live_action))
-       |> assign(:artist, Ash.get!(AshPhoenix.Test.Artist, id, actor: socket.assigns.current_user))}
-      end
-
-      defp page_title(:show), do: "Show Artist"
-      defp page_title(:edit), do: "Edit Artist"
       end
       """
       |> format_contents(show_path)

--- a/test/mix/tasks/ash_phoenix.gen.live_test.exs
+++ b/test/mix/tasks/ash_phoenix.gen.live_test.exs
@@ -457,36 +457,8 @@ defmodule Mix.Tasks.AshPhoenix.Gen.LiveTest do
       def mount(_params, _session, socket) do
       {:ok,
        socket
-       |> stream(:Artists, Ash.read!(AshPhoenix.Test.Artist, actor: socket.assigns[:current_user]))
-       |> assign_new(:current_user, fn -> nil end)}
-      end
-
-      @impl true
-      def handle_params(params, _url, socket) do
-      {:noreply, apply_action(socket, socket.assigns.live_action, params)}
-      end
-
-      defp apply_action(socket, :edit, %{"id" => id}) do
-      socket
-      |> assign(:page_title, "Edit Artist")
-      |> assign(:artist, Ash.get!(AshPhoenix.Test.Artist, id, actor: socket.assigns.current_user))
-      end
-
-      defp apply_action(socket, :new, _params) do
-      socket
-      |> assign(:page_title, "New Artist")
-      |> assign(:artist, nil)
-      end
-
-      defp apply_action(socket, :index, _params) do
-      socket
-      |> assign(:page_title, "Listing Artists")
-      |> assign(:artist, nil)
-      end
-
-      @impl true
-      def handle_info({AshPhoenixWeb.ArtistLive.FormComponent, {:saved, artist}}, socket) do
-      {:noreply, stream_insert(socket, :Artists, artist)}
+        |> assign(:page_title, "Listing Artists")
+        |> stream(:Artists, Ash.read!(AshPhoenix.Test.Artist, actor: socket.assigns[:current_user]))}
       end
 
       @impl true

--- a/test/mix/tasks/ash_phoenix.gen.live_test.exs
+++ b/test/mix/tasks/ash_phoenix.gen.live_test.exs
@@ -339,7 +339,7 @@ defmodule Mix.Tasks.AshPhoenix.Gen.LiveTest do
          artist =
            case params["id"] do
              nil -> nil
-             id -> Ash.get!(AshPhoenix.Test.Artist, id)
+             id -> Ash.get!(AshPhoenix.Test.Artist, id, actor: socket.assigns.current_user)
            end
 
          action = if is_nil(artist), do: "New", else: "Edit"


### PR DESCRIPTION
fixes some small issues:
* add missing actor to form get
* live_route_instructions telling you to add a route that no longer exists with new generators
* missing </Layouts.app> closing tag

removes defunct pieces that aren't in the new `phx.gen.live` anymore:
* index.ex.eex
  * remove handle_params and apply_action, since this live view no longer handles create + update
  * remove FormComponent handle_info, since that no longer exists
* show.ex.eex
  * remove handle_params and page_info, since this live view no longer handles update
  
existing generator tests updated to pass