### PR TITLE
Improvement: Add `to_form/2` in usage rules and improve error message when accessing a form without `to_form/2`

### DIFF
--- a/lib/ash_phoenix/form/form.ex
+++ b/lib/ash_phoenix/form/form.ex
@@ -377,6 +377,20 @@ defmodule AshPhoenix.Form do
     ]
   ]
 
+  @access_error """
+  Cannot access AshPhoenix.Form.
+
+  You're trying to access a form field but the form is not a Phoenix.HTML.Form struct.
+
+  If you are using Phoenix, you are likely missing to_form/2 call on the form.
+
+  Instead of:
+      AshPhoenix.Form.for_create(MyApp.Blog.Post, :create)
+
+  Use:
+      AshPhoenix.Form.for_create(MyApp.Blog.Post, :create) |> to_form()
+  """
+
   @doc false
   def for_opts, do: @for_opts
   @doc false
@@ -398,55 +412,13 @@ defmodule AshPhoenix.Form do
 
   @doc false
   @impl Access
-  def fetch(%__MODULE__{} = _form, key) do
-    raise """
-    Cannot access AshPhoenix.Form.
-
-    You're trying to access a form field using: form[#{inspect(key)}]
-
-    If you are using Phoenix, you are likely missing to_form/2 call on the form.
-
-    Instead of:
-        AshPhoenix.Form.for_create(MyApp.Blog.Post, :create)
-
-    Use:
-        AshPhoenix.Form.for_create(MyApp.Blog.Post, :create) |> to_form()
-    """
-  end
+  def fetch(%__MODULE__{} = _form, _key), do: raise(@access_error)
 
   @impl Access
-  def get_and_update(%__MODULE__{} = _form, key, _function) do
-    raise """
-    Cannot access AshPhoenix.Form.
-
-    You're trying to access a form field using: form[#{inspect(key)}]
-
-    If you are using Phoenix, you are likely missing to_form/2 call on the form.
-
-    Instead of:
-        AshPhoenix.Form.for_create(MyApp.Blog.Post, :create)
-
-    Use:
-        AshPhoenix.Form.for_create(MyApp.Blog.Post, :create) |> to_form()
-    """
-  end
+  def get_and_update(%__MODULE__{} = _form, _key, _function), do: raise(@access_error)
 
   @impl Access
-  def pop(%__MODULE__{} = _form, key) do
-    raise """
-    Cannot access AshPhoenix.Form.
-
-    You're trying to access a form field using: form[#{inspect(key)}]
-
-    If you are using Phoenix, you are likely missing to_form/2 call on the form.
-
-    Instead of:
-        AshPhoenix.Form.for_create(MyApp.Blog.Post, :create)
-
-    Use:
-        AshPhoenix.Form.for_create(MyApp.Blog.Post, :create) |> to_form()
-    """
-  end
+  def pop(%__MODULE__{} = _form, _key), do: raise(@access_error)
 
   @doc """
   Creates a form corresponding to any given action on a resource.

--- a/lib/ash_phoenix/form/form.ex
+++ b/lib/ash_phoenix/form/form.ex
@@ -394,6 +394,60 @@ defmodule AshPhoenix.Form do
 
   import AshPhoenix.FormData.Helpers
 
+  @behaviour Access
+
+  @doc false
+  @impl Access
+  def fetch(%__MODULE__{} = _form, key) do
+    raise """
+    Cannot access AshPhoenix.Form.
+
+    You're trying to access a form field using: form[#{inspect(key)}]
+
+    This error occurs because you're missing `to_form/2` call on the form.
+
+    Instead of:
+        AshPhoenix.Form.for_create(MyApp.Blog.Post, :create)
+
+    Use:
+        AshPhoenix.Form.for_create(MyApp.Blog.Post, :create) |> to_form()
+    """
+  end
+
+  @impl Access
+  def get_and_update(%__MODULE__{} = _form, key, _function) do
+    raise """
+    Cannot access AshPhoenix.Form.
+
+    You're trying to access a form field using: form[#{inspect(key)}]
+
+    This error occurs because you're missing `to_form/2` call on the form.
+
+    Instead of:
+        AshPhoenix.Form.for_create(MyApp.Blog.Post, :create)
+
+    Use:
+        AshPhoenix.Form.for_create(MyApp.Blog.Post, :create) |> to_form()
+    """
+  end
+
+  @impl Access
+  def pop(%__MODULE__{} = _form, key) do
+    raise """
+    Cannot access AshPhoenix.Form.
+
+    You're trying to access a form field using: form[#{inspect(key)}]
+
+    This error occurs because you're missing `to_form/2` call on the form.
+
+    Instead of:
+        AshPhoenix.Form.for_create(MyApp.Blog.Post, :create)
+
+    Use:
+        AshPhoenix.Form.for_create(MyApp.Blog.Post, :create) |> to_form()
+    """
+  end
+
   @doc """
   Creates a form corresponding to any given action on a resource.
 

--- a/lib/ash_phoenix/form/form.ex
+++ b/lib/ash_phoenix/form/form.ex
@@ -404,7 +404,7 @@ defmodule AshPhoenix.Form do
 
     You're trying to access a form field using: form[#{inspect(key)}]
 
-    This error occurs because you're missing `to_form/2` call on the form.
+    If you are using Phoenix, you are likely missing to_form/2 call on the form.
 
     Instead of:
         AshPhoenix.Form.for_create(MyApp.Blog.Post, :create)
@@ -421,7 +421,7 @@ defmodule AshPhoenix.Form do
 
     You're trying to access a form field using: form[#{inspect(key)}]
 
-    This error occurs because you're missing `to_form/2` call on the form.
+    If you are using Phoenix, you are likely missing to_form/2 call on the form.
 
     Instead of:
         AshPhoenix.Form.for_create(MyApp.Blog.Post, :create)
@@ -438,7 +438,7 @@ defmodule AshPhoenix.Form do
 
     You're trying to access a form field using: form[#{inspect(key)}]
 
-    This error occurs because you're missing `to_form/2` call on the form.
+    If you are using Phoenix, you are likely missing to_form/2 call on the form.
 
     Instead of:
         AshPhoenix.Form.for_create(MyApp.Blog.Post, :create)

--- a/test/form_test.exs
+++ b/test/form_test.exs
@@ -2364,4 +2364,35 @@ defmodule AshPhoenix.FormTest do
       assert Enum.count(persisted_post.comments) == 1
     end
   end
+
+  describe "Access behavior" do
+    test "accessing AshPhoenix.Form without to_form/2 raises error" do
+      form = Post |> Form.for_create(:create, domain: Domain)
+
+      try do
+        form[:text]
+      rescue
+        error ->
+          assert Exception.message(error) =~
+                   """
+                   Cannot access AshPhoenix.Form.
+
+                   You're trying to access a form field using: form[:text]
+
+                   This error occurs because you're missing `to_form/2` call on the form.
+
+                   Instead of:
+                       AshPhoenix.Form.for_create(MyApp.Blog.Post, :create)
+
+                   Use:
+                       AshPhoenix.Form.for_create(MyApp.Blog.Post, :create) |> to_form()
+                   """
+      end
+
+      phoenix_form = Phoenix.HTML.FormData.to_form(form, [])
+
+      field = phoenix_form[:text]
+      assert field.field == :text
+    end
+  end
 end

--- a/test/form_test.exs
+++ b/test/form_test.exs
@@ -2377,7 +2377,7 @@ defmodule AshPhoenix.FormTest do
                    """
                    Cannot access AshPhoenix.Form.
 
-                   You're trying to access a form field using: form[:text]
+                   You're trying to access a form field but the form is not a Phoenix.HTML.Form struct.
 
                    If you are using Phoenix, you are likely missing to_form/2 call on the form.
 

--- a/test/form_test.exs
+++ b/test/form_test.exs
@@ -2379,7 +2379,7 @@ defmodule AshPhoenix.FormTest do
 
                    You're trying to access a form field using: form[:text]
 
-                   This error occurs because you're missing `to_form/2` call on the form.
+                   If you are using Phoenix, you are likely missing to_form/2 call on the form.
 
                    Instead of:
                        AshPhoenix.Form.for_create(MyApp.Blog.Post, :create)

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -12,16 +12,16 @@ AshPhoenix provides `AshPhoenix.Form`, a powerful module for creating and handli
 
 ```elixir
 # For creating a new resource
-form = AshPhoenix.Form.for_create(MyApp.Blog.Post, :create)
+form = AshPhoenix.Form.for_create(MyApp.Blog.Post, :create) |> to_form()
 
 # For updating an existing resource
 post = MyApp.Blog.get_post!(post_id)
-form = AshPhoenix.Form.for_update(post, :update)
+form = AshPhoenix.Form.for_update(post, :update) |> to_form()
 
 # Form with initial value
 form = AshPhoenix.Form.for_create(MyApp.Blog.Post, :create,
   params: %{title: "Draft Title"}
-)
+) |> to_form()
 ```
 
 ### Code Interfaces


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
