### PR TITLE
Fix edge cases with keyset navigation

### DIFF
--- a/lib/ash_phoenix/live_view.ex
+++ b/lib/ash_phoenix/live_view.ex
@@ -350,6 +350,11 @@ defmodule AshPhoenix.LiveView do
     [limit: offset.limit, offset: (offset.offset || 0) + offset.limit]
   end
 
+  def page_link_params(%Ash.Page.Keyset{before: nil, after: nil}, "prev"), do: :invalid
+
+  def page_link_params(%Ash.Page.Keyset{before: nil, after: nil, more?: false}, "next"),
+    do: :invalid
+
   def page_link_params(%Ash.Page.Keyset{more?: false, after: nil, before: before}, "prev")
       when not is_nil(before) do
     :invalid


### PR DESCRIPTION
This should prevent the generation of:

- `prev` link when we’re on the first page
- `next` link when we’re on the first page that contains all available results

First encountered by [Jaeyson Anthony on Discord](https://discord.com/channels/711271361523351632/1298629277524295700/1348927149049905163) and just now by me in my personal project.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
