### PR TITLE
Fix error in `Form.for_update` on resource with `:date` type in `:union` types constraint

### DIFF
--- a/lib/ash_phoenix/form/form.ex
+++ b/lib/ash_phoenix/form/form.ex
@@ -511,12 +511,12 @@ defmodule AshPhoenix.Form do
           {module, module.__struct__(), opts}
 
         %Ash.Union{value: %resource{} = data, type: type} ->
-          if Ash.Resource.Info.resource?(resource) do
-            opts =
-              opts
-              |> Keyword.put_new(:params, %{})
-              |> Keyword.update!(:params, &Map.put(&1, "_union_type", to_string(type)))
+          opts =
+            opts
+            |> Keyword.put_new(:params, %{})
+            |> Keyword.update!(:params, &Map.put(&1, "_union_type", to_string(type)))
 
+          if Ash.Resource.Info.resource?(resource) do
             {resource, data, opts}
           else
             {AshPhoenix.Form.WrappedValue, %AshPhoenix.Form.WrappedValue{value: data}, opts}

--- a/test/auto_form_test.exs
+++ b/test/auto_form_test.exs
@@ -353,6 +353,24 @@ defmodule AshPhoenix.AutoFormTest do
                  }
                )
     end
+
+    test "it works for submitting a date inside of a union attribute type and creating update form" do
+      value_to_submit = Date.utc_today()
+
+      assert {:ok, %Post{union: %{value: ^value_to_submit, type: :date}} = post} =
+               AshPhoenix.Form.for_create(Post, :create, forms: [auto?: true])
+               |> AshPhoenix.Form.submit(
+                 params: %{
+                   "text" => "...",
+                   "union" => %{
+                     "_union_type" => "date",
+                     "value" => value_to_submit
+                   }
+                 }
+               )
+
+      form = AshPhoenix.Form.for_update(post, :update, forms: [auto?: true])
+    end
   end
 
   describe "list unions" do

--- a/test/auto_form_test.exs
+++ b/test/auto_form_test.exs
@@ -369,7 +369,19 @@ defmodule AshPhoenix.AutoFormTest do
                  }
                )
 
-      form = AshPhoenix.Form.for_update(post, :update, forms: [auto?: true])
+      new_date = Date.add(value_to_submit, 10)
+
+      assert {:ok, %Post{union: %{value: ^new_date, type: :date}}} =
+               AshPhoenix.Form.for_update(post, :update, forms: [auto?: true])
+               |> AshPhoenix.Form.submit(
+                 params: %{
+                   "text" => "...",
+                   "union" => %{
+                     "_union_type" => "date",
+                     "value" => new_date
+                   }
+                 }
+               )
     end
   end
 

--- a/test/support/resources/union_value.ex
+++ b/test/support/resources/union_value.ex
@@ -25,6 +25,9 @@ defmodule AshPhoenix.Test.UnionValue do
               value: [type: :string]
             ]
           ]
+        ],
+        date: [
+          type: :date
         ]
       ]
     ]


### PR DESCRIPTION
Fixes #414. 

The issue was that the `_union_type` was not set if the `value` inside of the `Union` was not  a resource. 

I would think that is a bug, but maybe I'm missing something so it's probably good that someone validates this.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
