### PR TITLE
Fix bug when creating a form for a union type which has `nil` as it's value

### DIFF
--- a/lib/ash_phoenix/form/form.ex
+++ b/lib/ash_phoenix/form/form.ex
@@ -5201,10 +5201,6 @@ defmodule AshPhoenix.Form do
             opts[:data]
           end
         end
-        |> case do
-          %Ash.Union{value: nil} -> nil
-          value -> value
-        end
 
       cond do
         opts[:update_action] ->

--- a/test/auto_form_test.exs
+++ b/test/auto_form_test.exs
@@ -383,6 +383,17 @@ defmodule AshPhoenix.AutoFormTest do
                  }
                )
     end
+
+    test "it automatically adds a form if a union attribute has a type, but no value" do
+      union_type = :predefined
+
+      assert %{forms: %{union: union_form}} =
+               SimplePost
+               |> Ash.create!(%{union: %Ash.Union{value: nil, type: union_type}})
+               |> AshPhoenix.Form.for_update(:update, forms: [auto?: true])
+
+      assert AshPhoenix.Form.value(union_form, :type) == union_type
+    end
   end
 
   describe "list unions" do


### PR DESCRIPTION
No child form was created when trying to create a update form on an instance that had `nil` as the Union's `value`.

I've added a test to demonstrate the issue.

I believe the issue was that the `%Ash.Union{value: nil}` was unwrapped to just `nil`.  
Unwrapping the Union means that the `type` information is lost (and in this case also causes the form to not be created)


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
