### PR TITLE
test: Add failing test for custom inputs in forms

### DIFF
--- a/test/ash_phoenix_test.exs
+++ b/test/ash_phoenix_test.exs
@@ -23,6 +23,17 @@ defmodule AshPhoenixTest do
              AshPhoenix.Test.Domain.form_to_update_user(%AshPhoenix.Test.User{id: id})
   end
 
+  test "functions on the domain take custom input into account" do
+    assert form =
+             %AshPhoenix.Form{} =
+             AshPhoenix.Test.Domain.form_to_create_with_custom_input(
+               %AshPhoenix.Test.Post{id: 1},
+               params: %{text: "some text"}
+             )
+
+    assert {:ok, _resource} = AshPhoenix.Form.submit(form)
+  end
+
   test "adding a form retains original params" do
     form =
       AshPhoenix.Test.Domain.form_to_create_post(

--- a/test/support/domain.ex
+++ b/test/support/domain.ex
@@ -2,10 +2,26 @@ defmodule AshPhoenix.Test.Domain do
   @moduledoc false
   use Ash.Domain, extensions: [AshPhoenix]
 
+  forms do
+    form :create_with_custom_input, args: [:post]
+  end
+
   resources do
     resource(AshPhoenix.Test.Artist)
     resource(AshPhoenix.Test.Author)
-    resource(AshPhoenix.Test.Comment)
+
+    resource AshPhoenix.Test.Comment do
+      define :create_with_custom_input do
+        action :create_with_post_id
+        args [:post]
+
+        custom_input :post, :struct do
+          constraints instance_of: AshPhoenix.Test.Post
+          transform to: :post_id, using: & &1.id
+        end
+      end
+    end
+
     resource(AshPhoenix.Test.Post)
     resource(AshPhoenix.Test.PostLink)
     resource(AshPhoenix.Test.PostWithDefault)

--- a/test/support/resources/comment.ex
+++ b/test/support/resources/comment.ex
@@ -32,6 +32,10 @@ defmodule AshPhoenix.Test.Comment do
       change(manage_relationship(:post, type: :direct_control))
     end
 
+    create :create_with_post_id do
+      accept [:post_id, :text]
+    end
+
     create :create_with_unknown_error do
       change(UnknownError)
     end
@@ -54,6 +58,6 @@ defmodule AshPhoenix.Test.Comment do
   end
 
   relationships do
-    belongs_to(:post, AshPhoenix.Test.Post)
+    belongs_to(:post, AshPhoenix.Test.Post, allow_nil?: false)
   end
 end


### PR DESCRIPTION
Custom inputs transformations are not taken into account when using AshPhoenix's
`forms`. Therefore, this test fails with a "post_id is required" message, even
though we have passed the a post as the first argument to
`form_to_create_with_custom_input`.


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
