### PR TITLE
bugfix: Ensure that `AshPhoenix.Form.update_params` callback always receives a map for nested forms

### DIFF
--- a/lib/ash_phoenix/form/form.ex
+++ b/lib/ash_phoenix/form/form.ex
@@ -3800,7 +3800,11 @@ defmodule AshPhoenix.Form do
       form = set_changed?(form)
 
       if opts[:validate?] do
-        validate(form, params(form, transform?: false, hidden?: true), opts[:validate_opts] || [])
+        validate(
+          form,
+          params(form, transform?: false, hidden?: true, indexed_lists?: true),
+          opts[:validate_opts] || []
+        )
       else
         form
       end


### PR DESCRIPTION
Previously, the validation of the form after removal would convert a map like `%{"0" => data}}` into `[data]` after removing a nested form.

This caused an error in my app when attempting to remove a form, then update_params like:

```elixir
      socket.assigns.form
      |> AshPhoenix.Form.update_params(fn params ->
        case get_in(params, ["organization_memberships", index]) do
          # ...
```

`params["organization_memberships"]` was now a list of maps, not an indexed map, so the whole line threw an error:

```
ArgumentError

the Access module supports only keyword lists (with atom keys), got: "0"
If you want to search lists of tuples, use List.keyfind/3
```

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
