### PR TITLE
Fix create takes resource instead of resource_singular

### DIFF
--- a/priv/templates/ash_phoenix.gen.live/new/form.ex.eex
+++ b/priv/templates/ash_phoenix.gen.live/new/form.ex.eex
@@ -105,7 +105,7 @@ defmodule <%= inspect Module.concat(@web_module, @resource_alias) %>Live.Form do
         <% @update_action -> %>
           AshPhoenix.Form.for_update(<%= @resource_singular %>, <%= inspect @update_action.name %>, as: <%= inspect @resource_singular %><%= @actor_opt %>)
         <% @create_action -> %>
-          AshPhoenix.Form.for_create(<%= @resource_singular %>, <%= inspect @create_action.name %>, as: <%= inspect @resource_singular %><%= @actor_opt %>)
+          AshPhoenix.Form.for_create(<%= @resource %>, <%= inspect @create_action.name %>, as: <%= inspect @resource_singular %><%= @actor_opt %>)
       <% end %>
 
     assign(socket, form: to_form(form))


### PR DESCRIPTION
Fixed a big in `mix ash_phoenix.gen.live` which when using only create action passed singular resource instead of resource module.

Closes https://github.com/ash-project/ash_phoenix/issues/442

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
