### PR TITLE
fix: filter empty values from array form params

### DIFF
--- a/lib/ash_phoenix/form/form.ex
+++ b/lib/ash_phoenix/form/form.ex
@@ -6149,11 +6149,6 @@ defmodule AshPhoenix.Form do
   # list-valued params before they reach the changeset. Set
   # `constraints: [empty_values: []]` on the attribute/argument to opt out
   # of filtering for a given field.
-  #
-  # Must match `Ash.Type`'s default for the `empty_values` array constraint
-  # (see `lib/ash/type/type.ex` `@array_constraints`).
-  @default_array_empty_values [""]
-
   defp strip_array_empty_values(form, params) when is_map(params) and not is_struct(params) do
     case resolve_form_action(form) do
       nil ->
@@ -6199,9 +6194,10 @@ defmodule AshPhoenix.Form do
   # input or when filtering is opted out (`empty_values: []`).
   defp array_empty_values(action, resource, key) do
     with name when is_atom(name) <- safe_existing_atom(key),
-         %{type: {:array, _}, constraints: constraints} <-
-           find_input(action, resource, name) do
-      case constraints[:empty_values] || @default_array_empty_values do
+         %{type: {:array, _} = type, constraints: constraints} <-
+           find_input(action, resource, name),
+         {:ok, resolved} <- Ash.Type.validate_constraints(type, constraints) do
+      case resolved[:empty_values] do
         [] -> nil
         values -> values
       end

--- a/lib/ash_phoenix/form/form.ex
+++ b/lib/ash_phoenix/form/form.ex
@@ -1341,6 +1341,8 @@ defmodule AshPhoenix.Form do
 
     prepare_source = form.prepare_source || (& &1)
 
+    new_params = strip_array_empty_values(form, new_params)
+
     new_params =
       if form.prepare_params do
         form.prepare_params.(new_params, :validate)
@@ -6135,6 +6137,102 @@ defmodule AshPhoenix.Form do
 
   defp form_for_method(:create), do: "post"
   defp form_for_method(_), do: "put"
+
+  # Phoenix's `multiple_select/3` and checkbox-group widgets emit a hidden
+  # `""` input so the field is always submitted. Plug parses those sentinels
+  # into the list, e.g. `%{"tags" => ["", "a", "b"]}`. Left in place, the
+  # `""` items break typed arrays: `:string` casts `""` to nil and trips
+  # `nil_items?: false`; `:integer` fails to cast outright.
+  #
+  # `{:array, _}` types in Ash declare an `empty_values` constraint
+  # (default `[""]`). We honour it by filtering matching items out of
+  # list-valued params before they reach the changeset. Set
+  # `constraints: [empty_values: []]` on the attribute/argument to opt out
+  # of filtering for a given field.
+  #
+  # Must match `Ash.Type`'s default for the `empty_values` array constraint
+  # (see `lib/ash/type/type.ex` `@array_constraints`).
+  @default_array_empty_values [""]
+
+  defp strip_array_empty_values(form, params) when is_map(params) and not is_struct(params) do
+    case resolve_form_action(form) do
+      nil ->
+        params
+
+      action ->
+        skip = nested_form_key_set(form)
+
+        Enum.reduce(params, params, fn {key, value}, acc ->
+          if is_list(value) && !MapSet.member?(skip, key) do
+            case array_empty_values(action, form.resource, key) do
+              nil -> acc
+              values -> Map.put(acc, key, Enum.reject(value, &(&1 in values)))
+            end
+          else
+            acc
+          end
+        end)
+    end
+  end
+
+  defp strip_array_empty_values(_form, params), do: params
+
+  defp resolve_form_action(form) do
+    case Map.get(form.source || %{}, :action) do
+      action_name when is_atom(action_name) and not is_nil(action_name) ->
+        Ash.Resource.Info.action(form.resource, action_name)
+
+      action ->
+        action
+    end
+  end
+
+  defp nested_form_key_set(form) do
+    form.form_keys
+    |> Keyword.keys()
+    |> Enum.flat_map(&[&1, to_string(&1)])
+    |> MapSet.new()
+  end
+
+  # Returns the non-empty list of sentinel values to strip from the list
+  # value of `key`, or nil when the key doesn't map to an `{:array, _}`
+  # input or when filtering is opted out (`empty_values: []`).
+  defp array_empty_values(action, resource, key) do
+    with name when is_atom(name) <- safe_existing_atom(key),
+         %{type: {:array, _}, constraints: constraints} <-
+           find_input(action, resource, name) do
+      case constraints[:empty_values] || @default_array_empty_values do
+        [] -> nil
+        values -> values
+      end
+    else
+      _ -> nil
+    end
+  end
+
+  # Action inputs are either explicit arguments or accepted attributes.
+  # Read actions have no `:accept` field, hence the `Map.get/3`.
+  defp find_input(action, resource, name) do
+    case Enum.find(action.arguments, &(&1.name == name)) do
+      nil ->
+        if name in (Map.get(action, :accept) || []) do
+          Ash.Resource.Info.attribute(resource, name)
+        end
+
+      argument ->
+        argument
+    end
+  end
+
+  defp safe_existing_atom(name) when is_atom(name), do: name
+
+  defp safe_existing_atom(name) when is_binary(name) do
+    String.to_existing_atom(name)
+  rescue
+    ArgumentError -> nil
+  end
+
+  defp safe_existing_atom(_), do: nil
 
   defp exclude_empty_fields(params, []) do
     params

--- a/test/form_test.exs
+++ b/test/form_test.exs
@@ -761,6 +761,71 @@ defmodule AshPhoenix.FormTest do
     assert post.title == nil
   end
 
+  describe "empty_values constraint on array fields" do
+    test "default [\"\"] is stripped from list-valued params (Phoenix multiple_select case)" do
+      form = Form.for_create(Post, :create, domain: Domain)
+      form = Form.validate(form, %{"text" => "x", "list_of_ints" => ["", "1", "2"]})
+
+      assert form.valid?, "expected form valid, got errors: #{inspect(form.source.errors)}"
+      assert form.params["list_of_ints"] == ["1", "2"]
+    end
+
+    test "cleared multi-select (only the hidden \"\") becomes an empty list" do
+      form = Form.for_create(Post, :create, domain: Domain)
+      form = Form.validate(form, %{"text" => "x", "list_of_ints" => [""]})
+
+      assert form.valid?
+      assert form.params["list_of_ints"] == []
+    end
+
+    test "non-list values for the same field are left alone" do
+      form = Form.for_create(Post, :create, domain: Domain)
+      form = Form.validate(form, %{"text" => "x", "title" => ""})
+
+      assert form.params["title"] == ""
+    end
+
+    test "honours empty_values on action arguments too" do
+      form =
+        Form.for_create(Post, :create_with_non_map_relationship_args, domain: Domain)
+
+      form = Form.validate(form, %{"comment_ids" => ["", "1", "2"]})
+
+      assert form.params["comment_ids"] == ["1", "2"]
+    end
+
+    test "respects a custom empty_values constraint on an attribute" do
+      form = Form.for_create(Post, :create, domain: Domain)
+
+      form =
+        Form.validate(form, %{
+          "text" => "x",
+          "list_of_strings_custom_empties" => ["skip", "", "a", "b"]
+        })
+
+      assert form.params["list_of_strings_custom_empties"] == ["a", "b"]
+    end
+
+    test "empty_values: [] on an attribute opts out of filtering" do
+      form = Form.for_create(Post, :create, domain: Domain)
+
+      form =
+        Form.validate(form, %{
+          "text" => "x",
+          "raw_list_of_strings" => ["", "a", "b"]
+        })
+
+      assert form.params["raw_list_of_strings"] == ["", "a", "b"]
+    end
+
+    test "unknown param keys pass through untouched" do
+      form = Form.for_create(Post, :create, domain: Domain)
+      form = Form.validate(form, %{"text" => "x", "not_a_field" => ["", "a"]})
+
+      assert form.params["not_a_field"] == ["", "a"]
+    end
+  end
+
   test "phoenix forms are accepted as input in some cases" do
     form = Form.for_create(PostWithDefault, :create, domain: Domain)
     form = AshPhoenix.Form.validate(form, %{"text" => ""}, errors: form.submitted_once?)

--- a/test/support/resources/post.ex
+++ b/test/support/resources/post.ex
@@ -21,6 +21,17 @@ defmodule AshPhoenix.Test.Post do
     attribute(:union, AshPhoenix.Test.UnionValue, public?: true)
     attribute(:union_array, {:array, AshPhoenix.Test.UnionValue}, public?: true)
     attribute(:list_of_ints, {:array, :integer}, public?: true)
+
+    attribute(:list_of_strings_custom_empties, {:array, :string},
+      public?: true,
+      constraints: [empty_values: ["skip", ""]]
+    )
+
+    attribute(:raw_list_of_strings, {:array, :string},
+      public?: true,
+      constraints: [empty_values: []]
+    )
+
     attribute(:title, :string, public?: true)
     attribute(:inline_atom_field, :atom, public?: true)
     attribute(:custom_atom_field, AshPhoenix.Test.Action, public?: true)


### PR DESCRIPTION
Multi-select and checkbox group form inputs in Phoenix submit a hidden "" sentinel for cleared or empty selections, which Ash's array casters reject.

Ash already supports an `empty_values` constraint on array attributes, but nothing was acting on it for form params. This honours the constraint at validate time, with per-field `constraints: [empty_values: []]` as an opt-out for fields that really do want "" preserved.

## Concrete case this fixes

A resource attribute holding a list of ISO 639-1 language codes:

```elixir
attribute :secondary_languages, {:array, MyApp.Types.Language} # an Ash.Type.Enum
```

Rendered with a hidden blank input (so the field is always present on submit, to allow for updates that remove all existing values) followed by one checkbox per language:

```html
<input type="hidden" name="secondary_languages[]" value="" />
<input type="checkbox" name="secondary_languages[]" value="ja" />
<input type="checkbox" name="secondary_languages[]" value="es" />
<!-- ...etc -->
```

Ticking "ja" gives Plug `%{"secondary_languages" => ["", "ja"]}`. The leading `""` hits `MyApp.Types.Language.cast_input/2`, fails to cast, and the form errors with "no nil values" even though the actual selection is perfectly valid. Clearing all selections sends `[""]` and the form rejects that too.

The workaround I think I've written in about five different apps is a `prepare_params` to apply wherever multi-selects are used:

```elixir
defp prepare_params(params, _phase) do
  Map.new(params, fn
    {k, v} when is_list(v) -> {k, Enum.reject(v, &(&1 == ""))}
    kv -> kv
  end)
end
```

But it should really be addressed at the AshPhoenix layer, with information we already have.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
