### PR TITLE
fix: unwrap `NewType` in auto-form `map_type?` check

### DIFF
--- a/lib/ash_phoenix/form/auto.ex
+++ b/lib/ash_phoenix/form/auto.ex
@@ -503,14 +503,19 @@ defmodule AshPhoenix.Form.Auto do
   defp map_type?(Ash.Type.Map), do: true
 
   defp map_type?(type) do
-    if Ash.Type.embedded_type?(type) do
-      if is_atom(type) && :erlang.function_exported(type, :admin_map_type?, 0) do
-        type.admin_map_type?()
-      else
+    cond do
+      Ash.Type.NewType.new_type?(type) ->
+        map_type?(Ash.Type.NewType.subtype_of(type))
+
+      Ash.Type.embedded_type?(type) ->
+        if is_atom(type) && :erlang.function_exported(type, :admin_map_type?, 0) do
+          type.admin_map_type?()
+        else
+          false
+        end
+
+      true ->
         false
-      end
-    else
-      false
     end
   end
 

--- a/test/auto_form_test.exs
+++ b/test/auto_form_test.exs
@@ -35,6 +35,17 @@ defmodule AshPhoenix.AutoFormTest do
     assert update_opts(forms[:linked_posts], %{})[:create_action] == :create
   end
 
+  test "it works when the relationship arg type is a NewType with subtype_of: :map" do
+    forms =
+      Post
+      |> auto_forms(:create_with_new_type_map_arg)
+      |> Keyword.get(:forms)
+
+    refute is_nil(forms[:comments])
+    assert update_opts(forms[:comments], %{})[:create_action] == :create
+    assert update_opts(forms[:comments], %{})[:update_action] == :update
+  end
+
   test "when using a non-map value it operates on maps, then transforms the params accordingly" do
     form =
       Post

--- a/test/support/resources/map_type.ex
+++ b/test/support/resources/map_type.ex
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: 2020 ash_phoenix contributors <https://github.com/ash-project/ash_phoenix/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshPhoenix.Test.MapType do
+  @moduledoc false
+  use Ash.Type.NewType, subtype_of: :map
+end

--- a/test/support/resources/post.ex
+++ b/test/support/resources/post.ex
@@ -86,6 +86,11 @@ defmodule AshPhoenix.Test.Post do
       change(manage_relationship(:comment_ids, :comments, type: :append_and_remove))
     end
 
+    create :create_with_new_type_map_arg do
+      argument(:comments, {:array, AshPhoenix.Test.MapType})
+      change(manage_relationship(:comments, type: :direct_control))
+    end
+
     create :create_author_required do
       argument(:author, :map, allow_nil?: false)
       change(manage_relationship(:author, type: :direct_control, on_missing: :unrelate))


### PR DESCRIPTION
Managed-relationship arguments typed as `Ash.Type.NewType` with `subtype_of: :map` were being filtered out of auto-generated forms because `map_type?/1` only matched explicit map types.

The `NewType` is now unwrapped, so the underlying subtype is checked.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
