### PR TITLE
fix: prevent false PendingCodegen when the check races the code reloader

### DIFF
--- a/lib/ash_phoenix/plug/check_codegen_status.ex
+++ b/lib/ash_phoenix/plug/check_codegen_status.ex
@@ -22,20 +22,22 @@ defmodule AshPhoenix.Plug.CheckCodegenStatus do
       :persistent_term.get(:ash_codegen_extensions, nil) ||
         set_extensions()
 
-    Enum.flat_map(extensions, fn extension ->
-      try do
-        if function_exported?(extension, :codegen, 1) do
-          extension.codegen(["--dev", "--check"])
-        end
+    with_build_lock(fn ->
+      Enum.flat_map(extensions, fn extension ->
+        try do
+          if function_exported?(extension, :codegen, 1) do
+            extension.codegen(["--dev", "--check"])
+          end
 
-        []
-      rescue
-        e in Ash.Error.Framework.PendingCodegen ->
-          Enum.to_list(e.diff)
-
-        _ ->
           []
-      end
+        rescue
+          e in Ash.Error.Framework.PendingCodegen ->
+            Enum.to_list(e.diff)
+
+          _ ->
+            []
+        end
+      end)
     end)
     |> case do
       [] ->
@@ -57,5 +59,24 @@ defmodule AshPhoenix.Plug.CheckCodegenStatus do
     extensions = Ash.Mix.Tasks.Helpers.extensions!([])
     :persistent_term.put(:ash_codegen_extensions, extensions)
     extensions
+  end
+
+  # The codegen check reads global compiler data: the Mix project stack and
+  # the current directory of the VM.
+  # In an umbrella project, `Phoenix.CodeReloader` changes this data on each
+  # request: `Mix.Dep.in_dependency/2` calls `Mix.Project.in_project/4` for
+  # each app, and that function calls `File.cd!/2`. This occurs also when no
+  # code is stale.
+  # If the check and a reload occur at the same time, the check reads paths
+  # that are not correct. The check then reports pending codegen that is not
+  # real.
+  # The code reloader holds the build lock. When the check also holds this
+  # lock, the two operations occur one after the other. This prevents the
+  # incorrect report.
+  # TODO: remove once we depend on Elixir 1.18
+  if Code.ensure_loaded?(Mix.Project) and function_exported?(Mix.Project, :with_build_lock, 1) do
+    defp with_build_lock(fun), do: Mix.Project.with_build_lock(fun)
+  else
+    defp with_build_lock(fun), do: fun.()
   end
 end

--- a/test/check_codegen_status_test.exs
+++ b/test/check_codegen_status_test.exs
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: 2020 ash_phoenix contributors <https://github.com/ash-project/ash_phoenix/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshPhoenix.Plug.CheckCodegenStatusTest do
+  # persistent_term and the build lock are global state
+  use ExUnit.Case, async: false
+
+  alias AshPhoenix.Plug.CheckCodegenStatus
+
+  defmodule CleanExtension do
+    def codegen(_args) do
+      test_pid = :persistent_term.get({__MODULE__, :test_pid}, nil)
+
+      # When a test is driving us, block until it says to continue. This pins
+      # the check open for as long as the test needs, instead of guessing a
+      # sleep duration.
+      if test_pid do
+        send(test_pid, {:codegen_started, self()})
+
+        receive do
+          :proceed -> :ok
+        end
+      end
+
+      :ok
+    end
+  end
+
+  defmodule PendingExtension do
+    def codegen(_args) do
+      raise Ash.Error.Framework.PendingCodegen,
+        diff: %{"priv/repo/migrations/1_example.exs" => "contents"}
+    end
+  end
+
+  setup do
+    on_exit(fn ->
+      :persistent_term.erase(:ash_codegen_extensions)
+      :persistent_term.erase({CleanExtension, :test_pid})
+    end)
+
+    :ok
+  end
+
+  test "passes the conn through when no codegen is pending" do
+    :persistent_term.put(:ash_codegen_extensions, [CleanExtension])
+
+    conn = Plug.Test.conn(:get, "/")
+    assert %Plug.Conn{} = CheckCodegenStatus.call(conn, [])
+  end
+
+  test "raises PendingCodegen when an extension reports a diff" do
+    :persistent_term.put(:ash_codegen_extensions, [PendingExtension])
+
+    conn = Plug.Test.conn(:get, "/")
+
+    assert_raise Plug.Conn.WrapperError, ~r/Pending/i, fn ->
+      CheckCodegenStatus.call(conn, [])
+    end
+  end
+
+  if Code.ensure_loaded?(Mix.Project) and function_exported?(Mix.Project, :with_build_lock, 1) do
+    test "holds the build lock while checking, so concurrent compilation must wait" do
+      # The check reads global compiler data: the Mix project stack and the
+      # current directory. Phoenix.CodeReloader changes this data when it
+      # compiles umbrella apps (Mix.Dep.in_dependency calls File.cd!).
+      # If the check does not hold the build lock, a reload can occur at the
+      # same time. The check then reads incorrect paths and reports pending
+      # codegen that is not real.
+      :persistent_term.put(:ash_codegen_extensions, [CleanExtension])
+      :persistent_term.put({CleanExtension, :test_pid}, self())
+
+      plug_task =
+        Task.async(fn ->
+          CheckCodegenStatus.call(Plug.Test.conn(:get, "/"), [])
+        end)
+
+      assert_receive {:codegen_started, codegen_pid}, 1_000
+
+      lock_task = Task.async(fn -> Mix.Project.with_build_lock(fn -> :acquired end) end)
+
+      # The check cannot have finished yet: codegen is blocked until we send
+      # :proceed below. So a lock that is still unavailable here means the
+      # check is holding it, not that the check already returned.
+      assert Task.yield(lock_task, 100) == nil,
+             "expected the codegen check to hold the build lock while running"
+
+      send(codegen_pid, :proceed)
+
+      assert %Plug.Conn{} = Task.await(plug_task, 2_000)
+      assert {:ok, :acquired} = Task.yield(lock_task, 1_000)
+    end
+  end
+end


### PR DESCRIPTION
# Context of the issue

We are working with an Umbrella app that has two Ash app inside it.

In development, the browser showed a `PendingCodegen` error page for 22 files. A refresh removed the error. Thus the report was not correct.

We read the source of the plug, of `ash_postgres`, and of the Phoenix code reloader. We found that the check reads global data: the Mix project stack and the current directory of the VM. We found that, in an umbrella project, the code reloader changes this data on each request. It goes into the folder of each app with `File.cd!/2`. This occurs also when no code is stale.

This causes the problem, because the check and the reloader can operate at the same time. They serve different requests, and they do not share a lock. The current directory is one value for the full VM, not one value for each request. Thus, when the reloader changes the directory, the check sees the change also. The check uses the directory to find the folder that contains the resource snapshots. During the overlap, it looks in the folder of a different app. That folder does not contain the snapshots. The check then thinks that all tables are new, and it reports all their files as pending.

# Proposed fix

`Phoenix.CodeReloader` holds the build lock when it examines and compiles the apps. We copied this pattern from Phoenix code reloader. The check now also holds the build lock. Then the check and the reloader operate one after the other.

A new test makes sure that the check holds the lock.

I decided to keep comments in the code and in the test because I do believe they are important when reading the code, but I would be glad to remove it you think it's not necessary.

# Pending question

Considering Phoenix is not testing this behavior, I am wondering if we should test it. The test is complicated, for a small benefit. I would remove it in favor of the comment. **WDYT?**

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

# How did we use AI to solve this issue?
We used AI for these tasks:

- AI found the cause, wrote a test and proposed a fix. We improve that fix concidering that it depends on the Elixir version.
- AI wrote the comment in the code, we simplified it but I decided to keep it as we might not understand why this peace of code is important just by reading the code.
- AI helped me to write this PR description.

