### PR TITLE
fix: match the type modules that exist in input_validations

### DIFF
--- a/lib/ash_phoenix/form/form.ex
+++ b/lib/ash_phoenix/form/form.ex
@@ -6436,22 +6436,24 @@ defmodule AshPhoenix.Form do
       end
     end
 
-    defp type_validations(%{type: Ash.Types.Integer, constraints: constraints}) do
+    defp type_validations(%{type: Ash.Type.Integer, constraints: constraints}) do
       constraints
       |> Kernel.||([])
       |> Keyword.take([:max, :min])
       |> Keyword.put(:step, 1)
     end
 
-    defp type_validations(%{type: Ash.Types.Decimal, constraints: constraints}) do
+    defp type_validations(%{type: Ash.Type.Decimal, constraints: constraints}) do
       constraints
       |> Kernel.||([])
       |> Keyword.take([:max, :min])
       |> Keyword.put(:step, "any")
     end
 
-    defp type_validations(%{type: Ash.Types.String, constraints: constraints}) do
-      if constraints[:trim?] do
+    defp type_validations(%{type: Ash.Type.String, constraints: constraints}) do
+      constraints = constraints || []
+
+      if Keyword.get(constraints, :trim?, true) do
         # We should consider using the `match` validation here, but we can't
         # add a title here, so we can't set an error message
         # min_length = to_string(constraints[:min_length])
@@ -6459,18 +6461,8 @@ defmodule AshPhoenix.Form do
         # [match: "(\S\s*){#{min_length},#{max_length}}"]
         []
       else
-        validations =
-          if constraints[:min_length] do
-            [min_length: constraints[:min_length]]
-          else
-            []
-          end
-
-        if constraints[:min_length] do
-          Keyword.put(constraints, :min_length, constraints[:min_length])
-        else
-          validations
-        end
+        [minlength: constraints[:min_length], maxlength: constraints[:max_length]]
+        |> Enum.reject(fn {_attribute, value} -> is_nil(value) end)
       end
     end
 

--- a/test/input_validations_test.exs
+++ b/test/input_validations_test.exs
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: 2020 ash_phoenix contributors <https://github.com/ash-project/ash_phoenix/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshPhoenix.InputValidationsTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  defmodule Measurement do
+    @moduledoc false
+    use Ash.Resource,
+      data_layer: Ash.DataLayer.Ets,
+      domain: AshPhoenix.Test.DummyDomain
+
+    actions do
+      defaults [:read]
+
+      create :create do
+        primary? true
+        accept :*
+      end
+    end
+
+    attributes do
+      uuid_primary_key :id
+
+      attribute :count, :integer do
+        public? true
+        allow_nil? false
+        constraints min: 1, max: 10
+      end
+
+      attribute :ratio, :decimal do
+        public? true
+        constraints min: 0, max: 1
+      end
+
+      attribute :code, :string do
+        public? true
+        constraints trim?: false, min_length: 2, max_length: 8
+      end
+
+      attribute :name, :string do
+        public? true
+        constraints max_length: 100
+      end
+    end
+  end
+
+  defp validations(field) do
+    Measurement
+    |> AshPhoenix.Form.for_create(:create, domain: AshPhoenix.Test.DummyDomain)
+    |> Phoenix.Component.to_form()
+    |> Phoenix.HTML.Form.input_validations(field)
+  end
+
+  test "an integer attribute gives its bounds and a whole-number step" do
+    assert Enum.sort(validations(:count)) ==
+             Enum.sort(required: true, min: 1, max: 10, step: 1)
+  end
+
+  test "a decimal attribute gives its bounds and accepts any step" do
+    assert Enum.sort(validations(:ratio)) ==
+             Enum.sort(
+               required: false,
+               min: Decimal.new("0"),
+               max: Decimal.new("1"),
+               step: "any"
+             )
+  end
+
+  test "an untrimmed string attribute gives its lengths as HTML attributes" do
+    assert Enum.sort(validations(:code)) ==
+             Enum.sort(required: false, minlength: 2, maxlength: 8)
+  end
+
+  test "a trimmed string attribute gives no lengths, because trimming happens after them" do
+    assert validations(:name) == [required: false]
+  end
+
+  test "a field the action does not accept gives nothing" do
+    assert validations(:missing) == []
+  end
+end


### PR DESCRIPTION
`input_validations/3` gives only `required`. It does not give the bounds and the lengths that the resource sets.

## Cause

`type_validations/1` matches on `Ash.Types.Integer`, `Ash.Types.Decimal` and `Ash.Types.String`. These modules do not exist. The correct names are `Ash.Type.Integer`, `Ash.Type.Decimal` and `Ash.Type.String`. Thus all three clauses are dead, and every field falls through to `type_validations(_)`.

```
iex> Code.ensure_loaded?(Ash.Types.Integer)
false
```

The clauses were correct when a module named `Ash.Types` existed.

## Second defect

The branch for an untrimmed string returns `Keyword.put(constraints, :min_length, ...)`. This returns all of the constraints, which includes `trim?` and `allow_empty?`. These are not HTML attributes. The branch also does not change `min_length` and `max_length` to `minlength` and `maxlength`.

## Change

- Match the type modules that exist.
- Give `minlength` and `maxlength` for an untrimmed string, and nothing else.
- Read `trim?` with the default of `Ash.Type.String`, which is `true`.

The behaviour for a trimmed string does not change. It stays empty, as the comment in the code explains.

## Effect

A form now gives these HTML attributes:

| Type | Attributes |
|---|---|
| integer | `min`, `max`, `step="1"` |
| decimal | `min`, `max`, `step="any"` |
| string, untrimmed | `minlength`, `maxlength` |
| string, trimmed | none |

Applications that use `input_validations/3` will show more attributes than before. This is the documented purpose of the function.

## Tests

`test/input_validations_test.exs` is new. It has 5 tests, one for each type and one for an unknown field. Without this change, 3 of the 5 tests fail.
